### PR TITLE
feat: mobile easter eggs + interactive particle sandbox

### DIFF
--- a/client/src/components/gui/GUIPortfolio.tsx
+++ b/client/src/components/gui/GUIPortfolio.tsx
@@ -5,6 +5,7 @@ import { loadPortfolioData } from '../../lib/portfolioDataLoader';
 import { loadPyPIStats, type PyPIStatsData } from '../../lib/pypiStats';
 import { apiConfig } from '../../config';
 import { guiTheme, accentHex, accentHoverHex, accentRgbCss } from '../../config/gui-theme.config';
+import { useGestureTrigger } from '../../hooks/useGestureTrigger';
 import Navbar from './Navbar';
 import HeroSection from './HeroSection';
 import AboutSection from './AboutSection';
@@ -23,13 +24,13 @@ import MatrixRain from './MatrixRain';
 import CursorTrail from './CursorTrail';
 import KonamiEasterEgg from './KonamiEasterEgg';
 import SnakeGame from './SnakeGame';
-import FilmGrain from './FilmGrain';
 
 const SECTIONS = ['about', 'skills', 'experience', 'work', 'projects', 'education', 'publication', 'contact'];
 
 export default function GUIPortfolio() {
   const [activeSection, setActiveSection] = useState<string>('');
   const containerRef = useRef<HTMLDivElement>(null);
+  const { konamiActive, snakeActive, resetKonami, resetSnake } = useGestureTrigger();
 
   // Apply GUI theme CSS variables from config (single source of truth)
   useEffect(() => {
@@ -109,8 +110,8 @@ export default function GUIPortfolio() {
       <MatrixRain />
       <MouseSpotlight />
       <CursorTrail />
-      <KonamiEasterEgg />
-      <SnakeGame />
+      <KonamiEasterEgg active={konamiActive} onClose={resetKonami} />
+      <SnakeGame active={snakeActive} onClose={resetSnake} />
       <Navbar activeSection={activeSection} data={portfolioData} />
       <HeroSection data={portfolioData} pypiStats={pypiStats ?? undefined} />
       <AboutSection data={portfolioData} />

--- a/client/src/components/gui/KonamiEasterEgg.tsx
+++ b/client/src/components/gui/KonamiEasterEgg.tsx
@@ -1,73 +1,38 @@
-import { useEffect, useState, useCallback, useRef } from 'react';
+import { useState, useCallback } from 'react';
 import { motion, AnimatePresence } from 'framer-motion';
 import ScrambleText from './ScrambleText';
+import ParticleSandbox from './ParticleSandbox';
 
-const KONAMI_SEQUENCE = [
-  'ArrowUp', 'ArrowUp', 'ArrowDown', 'ArrowDown',
-  'ArrowLeft', 'ArrowRight', 'ArrowLeft', 'ArrowRight',
-  'b', 'a',
-];
+interface KonamiEasterEggProps {
+  active: boolean;
+  onClose: () => void;
+}
 
-const STATS = [
-  { label: 'FRAMEWORK', value: 'React 18 + TypeScript' },
-  { label: 'BUILD TOOL', value: 'Vite 5' },
-  { label: 'ANIMATION', value: 'Framer Motion + Canvas' },
-  { label: 'STYLING', value: 'Tailwind CSS' },
-  { label: 'EASTER EGGS', value: '3 hidden' },
-  { label: 'CLEARANCE', value: 'LEVEL 5 — TOP SECRET' },
-];
-
-export default function KonamiEasterEgg() {
-  const [active, setActive] = useState(false);
+export default function KonamiEasterEgg({ active, onClose }: KonamiEasterEggProps) {
   const [shatter, setShatter] = useState(false);
-  const bufferRef = useRef<string[]>([]);
-  const timerRef = useRef<ReturnType<typeof setTimeout>>();
-
-  useEffect(() => {
-    const handleKey = (e: KeyboardEvent) => {
-      // Don't trigger if an input/textarea is focused
-      if (e.target instanceof HTMLInputElement || e.target instanceof HTMLTextAreaElement) return;
-      if (active) return;
-
-      bufferRef.current.push(e.key);
-      if (bufferRef.current.length > KONAMI_SEQUENCE.length) {
-        bufferRef.current.shift();
-      }
-
-      const match = KONAMI_SEQUENCE.every((k, i) => bufferRef.current[i] === k);
-      if (match) {
-        setActive(true);
-        bufferRef.current = [];
-      }
-    };
-
-    window.addEventListener('keydown', handleKey);
-    return () => window.removeEventListener('keydown', handleKey);
-  }, [active]);
-
-  // Auto-dismiss after 12s
-  useEffect(() => {
-    if (active && !shatter) {
-      timerRef.current = setTimeout(() => close(), 12000);
-      return () => clearTimeout(timerRef.current);
-    }
-  }, [active, shatter]);
+  const [gravityOn, setGravityOn] = useState(false);
+  const [explodeTrigger, setExplodeTrigger] = useState(0);
 
   const close = useCallback(() => {
-    setActive(false);
     setShatter(false);
-  }, []);
+    setGravityOn(false);
+    onClose();
+  }, [onClose]);
 
   const triggerShatter = useCallback(() => {
     setShatter(true);
     setTimeout(() => close(), 1200);
   }, [close]);
 
+  const handleExplode = useCallback(() => {
+    setExplodeTrigger((n) => n + 1);
+  }, []);
+
   return (
     <AnimatePresence>
       {active && (
         <motion.div
-          className="fixed inset-0 z-[100] flex items-center justify-center"
+          className="fixed inset-0 z-[100] flex flex-col items-center justify-center"
           initial={{ opacity: 0 }}
           animate={{ opacity: 1 }}
           exit={{ opacity: 0 }}
@@ -128,57 +93,60 @@ export default function KonamiEasterEgg() {
           {/* Content */}
           {!shatter && (
             <motion.div
-              className="relative z-10 max-w-lg w-full mx-6"
+              className="relative z-10 w-full max-w-2xl mx-4 flex flex-col items-center"
               initial={{ y: 50, opacity: 0 }}
               animate={{ y: 0, opacity: 1 }}
               transition={{ delay: 0.3, duration: 0.5 }}
             >
               {/* ACCESS GRANTED header */}
-              <div className="text-center mb-8">
-                <h2 className="font-display text-green-400 text-5xl sm:text-6xl tracking-wider mb-2">
+              <div className="text-center mb-4">
+                <h2 className="font-display text-green-400 text-4xl sm:text-6xl tracking-wider mb-2">
                   <ScrambleText text="ACCESS GRANTED" />
                 </h2>
                 <div className="h-px bg-green-500/40 mx-auto w-3/4" />
               </div>
 
-              {/* Security badge */}
+              {/* Particle sandbox */}
               <motion.div
-                className="border border-green-500/30 bg-green-500/5 p-6 mb-6 font-mono text-sm"
+                className="relative w-full border border-green-500/30 bg-black overflow-hidden"
+                style={{ height: 'min(50vh, 400px)' }}
                 initial={{ opacity: 0 }}
                 animate={{ opacity: 1 }}
-                transition={{ delay: 0.8 }}
+                transition={{ delay: 0.6 }}
               >
-                <div className="flex items-center gap-3 mb-4">
-                  <div className="w-3 h-3 bg-green-500 rounded-full animate-pulse" />
-                  <span className="text-green-400 text-xs tracking-widest">CLASSIFIED — PORTFOLIO INTERNALS</span>
-                </div>
-
-                <div className="grid grid-cols-1 gap-3">
-                  {STATS.map((stat, i) => (
-                    <motion.div
-                      key={stat.label}
-                      className="flex justify-between items-center border-b border-white/5 pb-2"
-                      initial={{ opacity: 0, x: -20 }}
-                      animate={{ opacity: 1, x: 0 }}
-                      transition={{ delay: 1 + i * 0.1 }}
-                    >
-                      <span className="text-zinc-500 text-xs">{stat.label}</span>
-                      <span className="text-green-400">{stat.value}</span>
-                    </motion.div>
-                  ))}
-                </div>
+                <ParticleSandbox gravityOn={gravityOn} explodeTrigger={explodeTrigger} />
+                <p className="absolute bottom-2 left-0 right-0 text-center text-green-500/30 text-xs font-mono pointer-events-none select-none">
+                  TAP TO ATTRACT · RELEASE TO REPULSE
+                </p>
               </motion.div>
 
-              {/* Self-destruct button */}
+              {/* Controls */}
               <motion.div
-                className="flex justify-center gap-4"
+                className="flex flex-wrap justify-center gap-3 mt-4"
                 initial={{ opacity: 0 }}
                 animate={{ opacity: 1 }}
-                transition={{ delay: 1.6 }}
+                transition={{ delay: 1 }}
               >
                 <button
+                  onClick={() => setGravityOn((g) => !g)}
+                  className={`px-4 py-2 border font-mono text-xs transition-all duration-200 ${
+                    gravityOn
+                      ? 'border-green-500/60 text-green-400 bg-green-500/10'
+                      : 'border-white/20 text-zinc-400 hover:border-green-500/40 hover:text-green-400'
+                  }`}
+                >
+                  {gravityOn ? '▼ GRAVITY ON' : '○ GRAVITY OFF'}
+                </button>
+                <button
+                  onClick={handleExplode}
+                  className="px-4 py-2 border border-green-500/40 text-green-400 font-mono text-xs
+                             hover:bg-green-500/10 transition-all duration-200"
+                >
+                  ✦ EXPLODE
+                </button>
+                <button
                   onClick={triggerShatter}
-                  className="px-6 py-3 border-2 border-red-500/60 text-red-400 font-mono text-sm
+                  className="px-4 py-2 border-2 border-red-500/60 text-red-400 font-mono text-xs
                              hover:bg-red-500/20 hover:border-red-400 transition-all duration-200
                              animate-pulse"
                 >
@@ -186,7 +154,7 @@ export default function KonamiEasterEgg() {
                 </button>
                 <button
                   onClick={close}
-                  className="px-6 py-3 border border-white/20 text-zinc-400 font-mono text-sm
+                  className="px-4 py-2 border border-white/20 text-zinc-400 font-mono text-xs
                              hover:border-green-500/40 hover:text-green-400 transition-all duration-200"
                 >
                   DISMISS [ESC]

--- a/client/src/components/gui/ParticleSandbox.tsx
+++ b/client/src/components/gui/ParticleSandbox.tsx
@@ -1,0 +1,290 @@
+import { useEffect, useRef, useCallback } from 'react';
+import { guiTheme } from '../../config/gui-theme.config';
+
+interface Particle {
+  x: number;
+  y: number;
+  vx: number;
+  vy: number;
+  life: number;
+  size: number;
+}
+
+interface ForceWell {
+  x: number;
+  y: number;
+  strength: number; // positive = attract, negative = repel
+  life: number;
+}
+
+const PARTICLE_COUNT = 180;
+const DAMPING = 0.98;
+const BOUNCE = 0.7;
+const TRAIL_ALPHA = 0.08;
+const FORCE_RADIUS = 200;
+
+interface ParticleSandboxProps {
+  gravityOn: boolean;
+  explodeTrigger: number; // increment to trigger explosion
+}
+
+export default function ParticleSandbox({ gravityOn, explodeTrigger }: ParticleSandboxProps) {
+  const canvasRef = useRef<HTMLCanvasElement>(null);
+  const particlesRef = useRef<Particle[]>([]);
+  const forcesRef = useRef<ForceWell[]>([]);
+  const mouseRef = useRef<{ x: number; y: number; down: boolean }>({ x: -1, y: -1, down: false });
+  const gravityRef = useRef(gravityOn);
+  const rafRef = useRef<number>(0);
+
+  gravityRef.current = gravityOn;
+
+  const initParticles = useCallback((w: number, h: number) => {
+    const cx = w / 2;
+    const cy = h / 2;
+    const particles: Particle[] = [];
+    for (let i = 0; i < PARTICLE_COUNT; i++) {
+      const angle = Math.random() * Math.PI * 2;
+      const speed = 2 + Math.random() * 6;
+      particles.push({
+        x: cx + (Math.random() - 0.5) * 20,
+        y: cy + (Math.random() - 0.5) * 20,
+        vx: Math.cos(angle) * speed,
+        vy: Math.sin(angle) * speed,
+        life: 0.5 + Math.random() * 0.5,
+        size: 1.5 + Math.random() * 2.5,
+      });
+    }
+    particlesRef.current = particles;
+  }, []);
+
+  // Re-explode when explodeTrigger changes
+  useEffect(() => {
+    const canvas = canvasRef.current;
+    if (!canvas) return;
+    const dpr = window.devicePixelRatio || 1;
+    const w = canvas.width / dpr;
+    const h = canvas.height / dpr;
+    initParticles(w, h);
+  }, [explodeTrigger, initParticles]);
+
+  useEffect(() => {
+    const canvas = canvasRef.current;
+    if (!canvas) return;
+    const ctx = canvas.getContext('2d');
+    if (!ctx) return;
+
+    const container = canvas.parentElement;
+    if (!container) return;
+
+    const dpr = window.devicePixelRatio || 1;
+    const resize = () => {
+      const rect = container.getBoundingClientRect();
+      canvas.width = rect.width * dpr;
+      canvas.height = rect.height * dpr;
+      canvas.style.width = `${rect.width}px`;
+      canvas.style.height = `${rect.height}px`;
+      ctx.setTransform(dpr, 0, 0, dpr, 0, 0);
+    };
+    resize();
+
+    const w = () => canvas.width / dpr;
+    const h = () => canvas.height / dpr;
+
+    if (particlesRef.current.length === 0) {
+      initParticles(w(), h());
+    }
+
+    const [r, g, b] = guiTheme.accentRgb;
+
+    // Mouse/touch handlers
+    const getPos = (e: MouseEvent | Touch): { x: number; y: number } => {
+      const rect = canvas.getBoundingClientRect();
+      return { x: e.clientX - rect.left, y: e.clientY - rect.top };
+    };
+
+    const onMouseMove = (e: MouseEvent) => {
+      const pos = getPos(e);
+      mouseRef.current.x = pos.x;
+      mouseRef.current.y = pos.y;
+    };
+    const onMouseDown = (e: MouseEvent) => {
+      mouseRef.current.down = true;
+      const pos = getPos(e);
+      mouseRef.current.x = pos.x;
+      mouseRef.current.y = pos.y;
+    };
+    const onMouseUp = () => {
+      if (mouseRef.current.down) {
+        // Shockwave on release
+        forcesRef.current.push({
+          x: mouseRef.current.x,
+          y: mouseRef.current.y,
+          strength: -15,
+          life: 0.5,
+        });
+      }
+      mouseRef.current.down = false;
+    };
+    const onMouseLeave = () => {
+      mouseRef.current.x = -1;
+      mouseRef.current.y = -1;
+      mouseRef.current.down = false;
+    };
+
+    const onTouchStart = (e: TouchEvent) => {
+      e.preventDefault();
+      const t = e.touches[0];
+      const pos = getPos(t);
+      mouseRef.current = { x: pos.x, y: pos.y, down: true };
+    };
+    const onTouchMove = (e: TouchEvent) => {
+      e.preventDefault();
+      const t = e.touches[0];
+      const pos = getPos(t);
+      mouseRef.current.x = pos.x;
+      mouseRef.current.y = pos.y;
+    };
+    const onTouchEnd = (e: TouchEvent) => {
+      e.preventDefault();
+      if (mouseRef.current.down) {
+        forcesRef.current.push({
+          x: mouseRef.current.x,
+          y: mouseRef.current.y,
+          strength: -15,
+          life: 0.5,
+        });
+      }
+      mouseRef.current.down = false;
+    };
+
+    canvas.addEventListener('mousemove', onMouseMove);
+    canvas.addEventListener('mousedown', onMouseDown);
+    canvas.addEventListener('mouseup', onMouseUp);
+    canvas.addEventListener('mouseleave', onMouseLeave);
+    canvas.addEventListener('touchstart', onTouchStart, { passive: false });
+    canvas.addEventListener('touchmove', onTouchMove, { passive: false });
+    canvas.addEventListener('touchend', onTouchEnd, { passive: false });
+
+    let lastTime = performance.now();
+
+    const animate = (now: number) => {
+      const dt = Math.min((now - lastTime) / 1000, 0.05);
+      lastTime = now;
+
+      const cw = w();
+      const ch = h();
+
+      // Fade trail
+      ctx.fillStyle = `rgba(0, 0, 0, ${TRAIL_ALPHA})`;
+      ctx.fillRect(0, 0, cw, ch);
+
+      const particles = particlesRef.current;
+      const mouse = mouseRef.current;
+      const forces = forcesRef.current;
+
+      // Decay force wells
+      for (let i = forces.length - 1; i >= 0; i--) {
+        forces[i].life -= dt;
+        if (forces[i].life <= 0) forces.splice(i, 1);
+      }
+
+      for (const p of particles) {
+        // Gravity
+        if (gravityRef.current) {
+          p.vy += 200 * dt;
+        }
+
+        // Mouse attraction (when held down)
+        if (mouse.down && mouse.x >= 0) {
+          const dx = mouse.x - p.x;
+          const dy = mouse.y - p.y;
+          const dist = Math.sqrt(dx * dx + dy * dy);
+          if (dist < FORCE_RADIUS && dist > 1) {
+            const force = 8 * (1 - dist / FORCE_RADIUS);
+            p.vx += (dx / dist) * force;
+            p.vy += (dy / dist) * force;
+          }
+        }
+
+        // Force wells (shockwaves)
+        for (const f of forces) {
+          const dx = p.x - f.x;
+          const dy = p.y - f.y;
+          const dist = Math.sqrt(dx * dx + dy * dy);
+          if (dist < FORCE_RADIUS && dist > 1) {
+            const power = f.strength * (1 - dist / FORCE_RADIUS) * (f.life * 2);
+            p.vx += (dx / dist) * power;
+            p.vy += (dy / dist) * power;
+          }
+        }
+
+        // Integrate
+        p.x += p.vx * dt * 60;
+        p.y += p.vy * dt * 60;
+        p.vx *= DAMPING;
+        p.vy *= DAMPING;
+
+        // Bounce off walls
+        if (p.x < 0) { p.x = 0; p.vx *= -BOUNCE; }
+        if (p.x > cw) { p.x = cw; p.vx *= -BOUNCE; }
+        if (p.y < 0) { p.y = 0; p.vy *= -BOUNCE; }
+        if (p.y > ch) { p.y = ch; p.vy *= -BOUNCE; }
+
+        // Draw particle
+        const speed = Math.sqrt(p.vx * p.vx + p.vy * p.vy);
+        const alpha = Math.min(0.3 + speed * 0.1, 1);
+        ctx.shadowColor = `rgba(${r}, ${g}, ${b}, 0.5)`;
+        ctx.shadowBlur = 4;
+        ctx.fillStyle = `rgba(${r}, ${g}, ${b}, ${alpha})`;
+        ctx.beginPath();
+        ctx.arc(p.x, p.y, p.size, 0, Math.PI * 2);
+        ctx.fill();
+      }
+      ctx.shadowBlur = 0;
+
+      // Draw force wells indicator
+      for (const f of forces) {
+        const alpha = f.life * 0.3;
+        const radius = FORCE_RADIUS * (1 - f.life);
+        ctx.strokeStyle = `rgba(${r}, ${g}, ${b}, ${alpha})`;
+        ctx.lineWidth = 1;
+        ctx.beginPath();
+        ctx.arc(f.x, f.y, radius, 0, Math.PI * 2);
+        ctx.stroke();
+      }
+
+      // Draw attraction indicator when holding
+      if (mouse.down && mouse.x >= 0) {
+        const pulse = Math.sin(now / 200) * 0.1 + 0.2;
+        ctx.strokeStyle = `rgba(${r}, ${g}, ${b}, ${pulse})`;
+        ctx.lineWidth = 1;
+        ctx.setLineDash([4, 4]);
+        ctx.beginPath();
+        ctx.arc(mouse.x, mouse.y, 30, 0, Math.PI * 2);
+        ctx.stroke();
+        ctx.setLineDash([]);
+      }
+
+      rafRef.current = requestAnimationFrame(animate);
+    };
+
+    rafRef.current = requestAnimationFrame(animate);
+
+    const onResize = () => resize();
+    window.addEventListener('resize', onResize);
+
+    return () => {
+      cancelAnimationFrame(rafRef.current);
+      window.removeEventListener('resize', onResize);
+      canvas.removeEventListener('mousemove', onMouseMove);
+      canvas.removeEventListener('mousedown', onMouseDown);
+      canvas.removeEventListener('mouseup', onMouseUp);
+      canvas.removeEventListener('mouseleave', onMouseLeave);
+      canvas.removeEventListener('touchstart', onTouchStart);
+      canvas.removeEventListener('touchmove', onTouchMove);
+      canvas.removeEventListener('touchend', onTouchEnd);
+    };
+  }, [initParticles]);
+
+  return <canvas ref={canvasRef} className="absolute inset-0 w-full h-full" />;
+}

--- a/client/src/components/gui/SnakeGame.tsx
+++ b/client/src/components/gui/SnakeGame.tsx
@@ -4,19 +4,21 @@ import { guiTheme } from '../../config/gui-theme.config';
 
 const GRID_SIZE = 20;
 const TICK_MS = 120;
-const TRIGGER_WORD = 'snake';
+const SWIPE_THRESHOLD = 30;
 
 type Direction = 'UP' | 'DOWN' | 'LEFT' | 'RIGHT';
 type Point = { x: number; y: number };
 
-export default function SnakeGame() {
-  const [active, setActive] = useState(false);
+interface SnakeGameProps {
+  active: boolean;
+  onClose: () => void;
+}
+
+export default function SnakeGame({ active, onClose }: SnakeGameProps) {
   const [score, setScore] = useState(0);
   const [gameOver, setGameOver] = useState(false);
   const canvasRef = useRef<HTMLCanvasElement>(null);
-  const bufferRef = useRef('');
 
-  // Direction refs to avoid stale closures in game loop
   const dirRef = useRef<Direction>('RIGHT');
   const nextDirRef = useRef<Direction>('RIGHT');
   const snakeRef = useRef<Point[]>([]);
@@ -24,30 +26,14 @@ export default function SnakeGame() {
   const scoreRef = useRef(0);
   const gameOverRef = useRef(false);
   const tickRef = useRef<ReturnType<typeof setInterval>>();
-
-  // Listen for "snake" typed anywhere
-  useEffect(() => {
-    const handleKey = (e: KeyboardEvent) => {
-      if (e.target instanceof HTMLInputElement || e.target instanceof HTMLTextAreaElement) return;
-      if (active) return;
-
-      bufferRef.current += e.key.toLowerCase();
-      if (bufferRef.current.length > 10) bufferRef.current = bufferRef.current.slice(-10);
-      if (bufferRef.current.endsWith(TRIGGER_WORD)) {
-        setActive(true);
-        bufferRef.current = '';
-      }
-    };
-    window.addEventListener('keydown', handleKey);
-    return () => window.removeEventListener('keydown', handleKey);
-  }, [active]);
+  const touchStartRef = useRef<{ x: number; y: number } | null>(null);
 
   const close = useCallback(() => {
-    setActive(false);
     setScore(0);
     setGameOver(false);
     if (tickRef.current) clearInterval(tickRef.current);
-  }, []);
+    onClose();
+  }, [onClose]);
 
   const placeFood = useCallback((snake: Point[], cols: number, rows: number): Point => {
     let food: Point;
@@ -57,13 +43,21 @@ export default function SnakeGame() {
     return food;
   }, []);
 
+  const applyDirection = useCallback((newDir: Direction) => {
+    const dir = dirRef.current;
+    if (newDir === 'UP' && dir !== 'DOWN') nextDirRef.current = 'UP';
+    if (newDir === 'DOWN' && dir !== 'UP') nextDirRef.current = 'DOWN';
+    if (newDir === 'LEFT' && dir !== 'RIGHT') nextDirRef.current = 'LEFT';
+    if (newDir === 'RIGHT' && dir !== 'LEFT') nextDirRef.current = 'RIGHT';
+  }, []);
+
   const startGame = useCallback(() => {
     const canvas = canvasRef.current;
     if (!canvas) return;
     const ctx = canvas.getContext('2d');
     if (!ctx) return;
 
-    const size = Math.min(window.innerWidth * 0.8, window.innerHeight * 0.7, 600);
+    const size = Math.min(window.innerWidth * 0.85, window.innerHeight * 0.65, 600);
     const dpr = window.devicePixelRatio || 1;
     canvas.width = size * dpr;
     canvas.height = size * dpr;
@@ -76,7 +70,6 @@ export default function SnakeGame() {
     const rows = GRID_SIZE;
     const [r, g, b] = guiTheme.accentRgb;
 
-    // Init snake
     const startSnake: Point[] = [
       { x: 5, y: Math.floor(rows / 2) },
       { x: 4, y: Math.floor(rows / 2) },
@@ -94,8 +87,6 @@ export default function SnakeGame() {
     function drawGrid() {
       ctx!.fillStyle = '#000';
       ctx!.fillRect(0, 0, size, size);
-
-      // Faint grid lines
       ctx!.strokeStyle = `rgba(${r}, ${g}, ${b}, 0.05)`;
       ctx!.lineWidth = 0.5;
       for (let i = 0; i <= cols; i++) {
@@ -118,19 +109,13 @@ export default function SnakeGame() {
         const seg = snake[i];
         const alpha = 1 - (i / snake.length) * 0.5;
         if (i === 0) {
-          // Head glow
           ctx!.shadowColor = `rgba(${r}, ${g}, ${b}, 0.6)`;
           ctx!.shadowBlur = 8;
         } else {
           ctx!.shadowBlur = 0;
         }
         ctx!.fillStyle = `rgba(${r}, ${g}, ${b}, ${alpha})`;
-        ctx!.fillRect(
-          seg.x * cellSize + 1,
-          seg.y * cellSize + 1,
-          cellSize - 2,
-          cellSize - 2,
-        );
+        ctx!.fillRect(seg.x * cellSize + 1, seg.y * cellSize + 1, cellSize - 2, cellSize - 2);
       }
       ctx!.shadowBlur = 0;
     }
@@ -141,21 +126,14 @@ export default function SnakeGame() {
       const cy = food.y * cellSize + cellSize / 2;
       const pulse = Math.sin(Date.now() / 200) * 0.15 + 0.85;
 
-      // Glow
       const grad = ctx!.createRadialGradient(cx, cy, 0, cx, cy, cellSize);
       grad.addColorStop(0, `rgba(255, 50, 50, ${0.3 * pulse})`);
       grad.addColorStop(1, 'transparent');
       ctx!.fillStyle = grad;
       ctx!.fillRect(food.x * cellSize - cellSize / 2, food.y * cellSize - cellSize / 2, cellSize * 2, cellSize * 2);
 
-      // Food body
       ctx!.fillStyle = `rgba(255, 80, 80, ${pulse})`;
-      ctx!.fillRect(
-        food.x * cellSize + 3,
-        food.y * cellSize + 3,
-        cellSize - 6,
-        cellSize - 6,
-      );
+      ctx!.fillRect(food.x * cellSize + 3, food.y * cellSize + 3, cellSize - 6, cellSize - 6);
     }
 
     function tick() {
@@ -172,14 +150,12 @@ export default function SnakeGame() {
         case 'RIGHT': head.x++; break;
       }
 
-      // Wall collision
       if (head.x < 0 || head.x >= cols || head.y < 0 || head.y >= rows) {
         gameOverRef.current = true;
         setGameOver(true);
         return;
       }
 
-      // Self collision
       if (snake.some(s => s.x === head.x && s.y === head.y)) {
         gameOverRef.current = true;
         setGameOver(true);
@@ -188,7 +164,6 @@ export default function SnakeGame() {
 
       snake.unshift(head);
 
-      // Eat food
       if (head.x === foodRef.current.x && head.y === foodRef.current.y) {
         scoreRef.current += 10;
         setScore(scoreRef.current);
@@ -205,18 +180,16 @@ export default function SnakeGame() {
       drawSnake();
     }
 
-    // Game loop
     if (tickRef.current) clearInterval(tickRef.current);
     tickRef.current = setInterval(() => {
       tick();
       render();
     }, TICK_MS);
 
-    // Initial render
     render();
   }, [active, placeFood]);
 
-  // Direction keys
+  // Keyboard controls
   useEffect(() => {
     if (!active) return;
 
@@ -228,24 +201,81 @@ export default function SnakeGame() {
         return;
       }
 
-      const dir = dirRef.current;
       switch (e.key) {
-        case 'ArrowUp': if (dir !== 'DOWN') nextDirRef.current = 'UP'; break;
-        case 'ArrowDown': if (dir !== 'UP') nextDirRef.current = 'DOWN'; break;
-        case 'ArrowLeft': if (dir !== 'RIGHT') nextDirRef.current = 'LEFT'; break;
-        case 'ArrowRight': if (dir !== 'LEFT') nextDirRef.current = 'RIGHT'; break;
+        case 'ArrowUp': applyDirection('UP'); break;
+        case 'ArrowDown': applyDirection('DOWN'); break;
+        case 'ArrowLeft': applyDirection('LEFT'); break;
+        case 'ArrowRight': applyDirection('RIGHT'); break;
       }
       e.preventDefault();
     };
 
     window.addEventListener('keydown', handleKey);
     return () => window.removeEventListener('keydown', handleKey);
-  }, [active, close, startGame]);
+  }, [active, close, startGame, applyDirection]);
+
+  // Swipe controls on canvas
+  useEffect(() => {
+    if (!active) return;
+    const canvas = canvasRef.current;
+    if (!canvas) return;
+
+    const onTouchStart = (e: TouchEvent) => {
+      e.preventDefault();
+      const t = e.touches[0];
+      touchStartRef.current = { x: t.clientX, y: t.clientY };
+    };
+
+    const onTouchMove = (e: TouchEvent) => {
+      e.preventDefault(); // Prevent page scroll while playing
+    };
+
+    const onTouchEnd = (e: TouchEvent) => {
+      e.preventDefault();
+      if (!touchStartRef.current) return;
+      const t = e.changedTouches[0];
+      const dx = t.clientX - touchStartRef.current.x;
+      const dy = t.clientY - touchStartRef.current.y;
+      touchStartRef.current = null;
+
+      const ax = Math.abs(dx);
+      const ay = Math.abs(dy);
+
+      if (Math.max(ax, ay) < SWIPE_THRESHOLD) {
+        // Tap — on game over, restart
+        if (gameOverRef.current) startGame();
+        return;
+      }
+
+      if (gameOverRef.current) return;
+
+      if (ax > ay) {
+        applyDirection(dx > 0 ? 'RIGHT' : 'LEFT');
+      } else {
+        applyDirection(dy > 0 ? 'DOWN' : 'UP');
+      }
+    };
+
+    canvas.addEventListener('touchstart', onTouchStart, { passive: false });
+    canvas.addEventListener('touchmove', onTouchMove, { passive: false });
+    canvas.addEventListener('touchend', onTouchEnd, { passive: false });
+
+    return () => {
+      canvas.removeEventListener('touchstart', onTouchStart);
+      canvas.removeEventListener('touchmove', onTouchMove);
+      canvas.removeEventListener('touchend', onTouchEnd);
+    };
+  }, [active, startGame, applyDirection]);
 
   // Start game when activated
   useEffect(() => {
     if (active) startGame();
+    return () => {
+      if (tickRef.current) clearInterval(tickRef.current);
+    };
   }, [active, startGame]);
+
+  const isTouchDevice = 'ontouchstart' in window || navigator.maxTouchPoints > 0;
 
   return (
     <AnimatePresence>
@@ -258,14 +288,14 @@ export default function SnakeGame() {
           transition={{ duration: 0.3 }}
         >
           {/* Header */}
-          <div className="flex items-center gap-8 mb-4 font-mono text-sm">
+          <div className="flex items-center gap-6 sm:gap-8 mb-4 font-mono text-sm">
             <span className="text-green-400">SNAKE</span>
             <span className="text-white">SCORE: {score}</span>
             <button
               onClick={close}
               className="text-zinc-500 hover:text-red-400 transition-colors"
             >
-              [ESC] CLOSE
+              CLOSE
             </button>
           </div>
 
@@ -287,20 +317,22 @@ export default function SnakeGame() {
                     onClick={startGame}
                     className="px-4 py-2 border border-green-500/40 text-green-400 hover:bg-green-500/10 transition-colors"
                   >
-                    [ENTER] RETRY
+                    {isTouchDevice ? 'TAP TO ' : '[ENTER] '}RETRY
                   </button>
                   <button
                     onClick={close}
                     className="px-4 py-2 border border-white/20 text-zinc-400 hover:text-white transition-colors"
                   >
-                    [ESC] QUIT
+                    QUIT
                   </button>
                 </div>
               </motion.div>
             )}
           </div>
 
-          <p className="text-zinc-600 font-mono text-xs mt-4">Arrow keys to move</p>
+          <p className="text-zinc-600 font-mono text-xs mt-4">
+            {isTouchDevice ? 'Swipe to move · Tap to retry' : 'Arrow keys to move'}
+          </p>
         </motion.div>
       )}
     </AnimatePresence>

--- a/client/src/hooks/useGestureTrigger.ts
+++ b/client/src/hooks/useGestureTrigger.ts
@@ -1,0 +1,232 @@
+import { useEffect, useRef, useCallback, useState } from 'react';
+
+/**
+ * Directional stroke-segment gesture recognizer.
+ * Recognizes drawn letters "K" and "S" on touch devices,
+ * plus keyboard triggers (Konami code / typing "snake") on desktop.
+ */
+
+type Dir = 'U' | 'D' | 'L' | 'R' | 'UR' | 'UL' | 'DR' | 'DL';
+type Point = { x: number; y: number; t: number };
+
+const MIN_PATH_LEN = 120; // px total path length
+const MAX_GESTURE_MS = 2000; // max gesture duration
+const SEGMENT_MIN_LEN = 30; // min px for a directional segment
+
+const KONAMI_SEQUENCE = [
+  'ArrowUp', 'ArrowUp', 'ArrowDown', 'ArrowDown',
+  'ArrowLeft', 'ArrowRight', 'ArrowLeft', 'ArrowRight',
+  'b', 'a',
+];
+
+const SNAKE_TRIGGER = 'snake';
+
+function getDirection(dx: number, dy: number): Dir {
+  const ax = Math.abs(dx);
+  const ay = Math.abs(dy);
+  const ratio = Math.min(ax, ay) / Math.max(ax, ay);
+
+  // If one axis dominates (ratio < 0.4), it's a cardinal direction
+  if (ratio < 0.4) {
+    if (ax > ay) return dx > 0 ? 'R' : 'L';
+    return dy > 0 ? 'D' : 'U';
+  }
+  // Diagonal
+  if (dx > 0 && dy < 0) return 'UR';
+  if (dx > 0 && dy > 0) return 'DR';
+  if (dx < 0 && dy < 0) return 'UL';
+  return 'DL';
+}
+
+function segmentize(points: Point[]): Dir[] {
+  if (points.length < 3) return [];
+
+  const segments: Dir[] = [];
+  let segStart = 0;
+
+  for (let i = 1; i < points.length; i++) {
+    const dx = points[i].x - points[segStart].x;
+    const dy = points[i].y - points[segStart].y;
+    const dist = Math.sqrt(dx * dx + dy * dy);
+
+    if (dist < SEGMENT_MIN_LEN) continue;
+
+    const dir = getDirection(dx, dy);
+
+    // Only add if different from last segment
+    if (segments.length === 0 || segments[segments.length - 1] !== dir) {
+      segments.push(dir);
+    }
+    segStart = i;
+  }
+
+  return segments;
+}
+
+function totalPathLength(points: Point[]): number {
+  let len = 0;
+  for (let i = 1; i < points.length; i++) {
+    const dx = points[i].x - points[i - 1].x;
+    const dy = points[i].y - points[i - 1].y;
+    len += Math.sqrt(dx * dx + dy * dy);
+  }
+  return len;
+}
+
+// K: vertical down stroke, then up-right diagonal, then down-right diagonal
+// Allows some flexibility in the exact sequence
+function matchesK(segs: Dir[]): boolean {
+  if (segs.length < 3 || segs.length > 5) return false;
+
+  // Pattern: D → UR → DR  (the classic K shape)
+  // Also accept: D → U → DR (if the user draws the arm as up then down-right)
+  const patterns: Dir[][] = [
+    ['D', 'UR', 'DR'],
+    ['D', 'UR', 'R'],
+    ['D', 'UR', 'D'],
+    ['D', 'U', 'DR'],
+    ['D', 'R', 'DR'],
+  ];
+
+  return patterns.some(pattern => {
+    if (segs.length < pattern.length) return false;
+    // Check if pattern appears as subsequence at start
+    let pi = 0;
+    for (let si = 0; si < segs.length && pi < pattern.length; si++) {
+      if (segs[si] === pattern[pi]) pi++;
+    }
+    return pi === pattern.length;
+  });
+}
+
+// S: right → down-left → right (S-curve)
+function matchesS(segs: Dir[]): boolean {
+  if (segs.length < 2 || segs.length > 5) return false;
+
+  const patterns: Dir[][] = [
+    ['R', 'DL', 'R'],
+    ['R', 'D', 'R'],
+    ['R', 'DL', 'DR'],
+    ['R', 'D', 'L'],
+    ['DR', 'DL', 'DR'],
+    ['R', 'L', 'R'],
+    ['DR', 'L', 'R'],
+    ['DR', 'DL', 'R'],
+  ];
+
+  return patterns.some(pattern => {
+    if (segs.length < pattern.length) return false;
+    let pi = 0;
+    for (let si = 0; si < segs.length && pi < pattern.length; si++) {
+      if (segs[si] === pattern[pi]) pi++;
+    }
+    return pi === pattern.length;
+  });
+}
+
+export function useGestureTrigger() {
+  const [konamiActive, setKonamiActive] = useState(false);
+  const [snakeActive, setSnakeActive] = useState(false);
+
+  const touchPointsRef = useRef<Point[]>([]);
+  const konamiBufferRef = useRef<string[]>([]);
+  const snakeBufferRef = useRef('');
+
+  const resetKonami = useCallback(() => setKonamiActive(false), []);
+  const resetSnake = useCallback(() => setSnakeActive(false), []);
+
+  // ── Touch gesture recognition ──
+  useEffect(() => {
+    const onTouchStart = (e: TouchEvent) => {
+      if (konamiActive || snakeActive) return;
+      // Only single-finger gestures for letter drawing
+      if (e.touches.length !== 1) return;
+      const t = e.touches[0];
+      touchPointsRef.current = [{ x: t.clientX, y: t.clientY, t: Date.now() }];
+    };
+
+    const onTouchMove = (e: TouchEvent) => {
+      if (konamiActive || snakeActive) return;
+      if (e.touches.length !== 1) return;
+      const t = e.touches[0];
+      touchPointsRef.current.push({ x: t.clientX, y: t.clientY, t: Date.now() });
+    };
+
+    const onTouchEnd = () => {
+      if (konamiActive || snakeActive) return;
+      const points = touchPointsRef.current;
+      if (points.length < 5) return;
+
+      const duration = points[points.length - 1].t - points[0].t;
+      if (duration > MAX_GESTURE_MS) return;
+
+      const pathLen = totalPathLength(points);
+      if (pathLen < MIN_PATH_LEN) return;
+
+      const segments = segmentize(points);
+      if (segments.length < 2) return; // Must have direction changes (not a scroll)
+
+      if (matchesK(segments)) {
+        setKonamiActive(true);
+      } else if (matchesS(segments)) {
+        setSnakeActive(true);
+      }
+
+      touchPointsRef.current = [];
+    };
+
+    document.addEventListener('touchstart', onTouchStart, { passive: true });
+    document.addEventListener('touchmove', onTouchMove, { passive: true });
+    document.addEventListener('touchend', onTouchEnd);
+
+    return () => {
+      document.removeEventListener('touchstart', onTouchStart);
+      document.removeEventListener('touchmove', onTouchMove);
+      document.removeEventListener('touchend', onTouchEnd);
+    };
+  }, [konamiActive, snakeActive]);
+
+  // ── Keyboard: Konami code ──
+  useEffect(() => {
+    const handleKey = (e: KeyboardEvent) => {
+      if (e.target instanceof HTMLInputElement || e.target instanceof HTMLTextAreaElement) return;
+      if (konamiActive) return;
+
+      konamiBufferRef.current.push(e.key);
+      if (konamiBufferRef.current.length > KONAMI_SEQUENCE.length) {
+        konamiBufferRef.current.shift();
+      }
+
+      if (KONAMI_SEQUENCE.every((k, i) => konamiBufferRef.current[i] === k)) {
+        setKonamiActive(true);
+        konamiBufferRef.current = [];
+      }
+    };
+
+    window.addEventListener('keydown', handleKey);
+    return () => window.removeEventListener('keydown', handleKey);
+  }, [konamiActive]);
+
+  // ── Keyboard: type "snake" ──
+  useEffect(() => {
+    const handleKey = (e: KeyboardEvent) => {
+      if (e.target instanceof HTMLInputElement || e.target instanceof HTMLTextAreaElement) return;
+      if (snakeActive) return;
+
+      snakeBufferRef.current += e.key.toLowerCase();
+      if (snakeBufferRef.current.length > 10) {
+        snakeBufferRef.current = snakeBufferRef.current.slice(-10);
+      }
+
+      if (snakeBufferRef.current.endsWith(SNAKE_TRIGGER)) {
+        setSnakeActive(true);
+        snakeBufferRef.current = '';
+      }
+    };
+
+    window.addEventListener('keydown', handleKey);
+    return () => window.removeEventListener('keydown', handleKey);
+  }, [snakeActive]);
+
+  return { konamiActive, snakeActive, resetKonami, resetSnake };
+}


### PR DESCRIPTION
## Summary

- **Mobile gesture triggers**: Draw "K" on screen to trigger Konami easter egg, draw "S" for Snake game (directional stroke-segment recognition with scroll conflict prevention). Desktop keyboard triggers (Konami code + typing "snake") still work.
- **Interactive Konami content**: Replaced the generic static tech stack stats with a particle physics sandbox — 180 green particles with gravity toggle, tap-to-attract, release-to-repulse shockwave, and explode button.
- **Snake swipe controls**: Swipe on the game canvas to change direction on mobile. Tap to retry on game over. Adaptive hint text.
- **Refactored architecture**: Both easter eggs are now props-driven (`active`/`onClose`) with trigger state managed by a shared `useGestureTrigger` hook in GUIPortfolio.

## New files
- `client/src/hooks/useGestureTrigger.ts` — shared hook for touch gesture + keyboard triggers
- `client/src/components/gui/ParticleSandbox.tsx` — interactive canvas particle system

## Test plan
- [ ] Desktop: type Konami code (up x2, down x2, left, right, left, right, B, A) → particle sandbox opens
- [ ] Desktop: type "snake" → Snake game opens with arrow key controls
- [ ] Mobile: draw letter "K" with finger → Konami triggers
- [ ] Mobile: draw letter "S" with finger → Snake triggers
- [ ] Mobile: swipe to control Snake direction, tap to retry on game over
- [ ] Particle sandbox: tap to attract, release to repulse, gravity toggle, explode button all work
- [ ] Normal scrolling does NOT accidentally trigger easter eggs
- [ ] Build passes cleanly

https://claude.ai/code/session_01DmxwGMqfrtLAmtu8shdK7j