### PR TITLE
sync: TUI revamp + replicate restructure + AI prompt rewrite (PR #10 → main)

### DIFF
--- a/client/src/App.tsx
+++ b/client/src/App.tsx
@@ -1,4 +1,4 @@
-import { useEffect } from "react";
+import { useEffect, useState } from "react";
 import { QueryClientProvider } from "@tanstack/react-query";
 import { AnimatePresence } from "framer-motion";
 import { queryClient } from "./lib/queryClient";
@@ -9,6 +9,7 @@ import { useTabOutTitle } from "./hooks/useTabOutTitle";
 import { runConsoleEasterEgg } from "./lib/consoleEasterEgg";
 import { toggleFullscreen } from "./lib/fullscreen";
 import * as audio from "./lib/audio";
+import { applyColorTheme, getSavedTheme } from "./config";
 import SplashPage from "./components/SplashPage";
 import TerminalView from "./components/TerminalView";
 import GUIPortfolio from "./components/gui/GUIPortfolio";
@@ -26,6 +27,18 @@ function ViewRouter() {
 }
 
 function App() {
+  // Restore the saved color theme on first paint, BEFORE any view
+  // mounts. Previously this lived inside GUIPortfolio's mount effect,
+  // so loading the page directly into the TUI (or refreshing while in
+  // the TUI) skipped theme application — leaving CSS vars at the
+  // matrix-green :root defaults even though localStorage said otherwise.
+  // useState's lazy init runs synchronously before children render.
+  const [_themeApplied] = useState(() => {
+    if (typeof document === 'undefined') return false;
+    applyColorTheme(getSavedTheme());
+    return true;
+  });
+
   // One-time console greeting — runs once on mount.
   useEffect(() => { runConsoleEasterEgg(); }, []);
   // Tab-out title swap — restores on return.

--- a/client/src/components/Terminal.tsx
+++ b/client/src/components/Terminal.tsx
@@ -498,16 +498,22 @@ function Terminal({ onSwitchToGUI }: TerminalProps) {
 
   return (
     <div className="terminal-glow terminal-scanlines relative w-full h-screen bg-terminal-black">
+      {/* Shared film-grain atmosphere — also used by the GUI so both
+           views share one noise floor. Paused on reduced-motion. */}
+      <div className="film-grain" aria-hidden="true" />
       <div className="flex flex-col h-full">
-        {/* Terminal Header */}
-        <div className="border-b border-terminal-green/30 p-2 sm:p-4 flex items-center justify-between">
+        {/* Terminal Header — traffic-light dots keep the retro chrome,
+             and the path segment now reflects the Starship-style dir. */}
+        <div className="border-b border-tui-accent-dim/30 p-2 sm:p-4 flex items-center justify-between">
           <div className="flex items-center space-x-2 sm:space-x-4">
-            <div className="flex space-x-1">
-              <div className="w-3 h-3 rounded-full bg-terminal-red"></div>
-              <div className="w-3 h-3 rounded-full bg-terminal-yellow"></div>
+            <div className="flex space-x-1" aria-hidden="true">
+              <div className="w-3 h-3 rounded-full bg-tui-error"></div>
+              <div className="w-3 h-3 rounded-full bg-tui-warn"></div>
               <div className="w-3 h-3 rounded-full bg-terminal-green"></div>
             </div>
-            <span className="text-xs sm:text-sm truncate">~/portfolio</span>
+            <span className="text-xs sm:text-sm truncate font-mono text-tui-accent-dim">
+              {promptUser}@{promptHost}:{currentDir}
+            </span>
           </div>
           <div className="flex items-center space-x-2 text-xs opacity-60">
             {isInstalled && <span className="hidden sm:block font-mono">pwa</span>}

--- a/client/src/components/Terminal.tsx
+++ b/client/src/components/Terminal.tsx
@@ -656,8 +656,14 @@ function Terminal({ onSwitchToGUI }: TerminalProps) {
         </div>
 
         {/* Command Input — Starship-style prompt with right-aligned
-            exit-status + theme name. Dir changes with navigation commands. */}
+            exit-status + theme name. Dir changes with navigation
+            commands. Inner content is constrained to match the Block
+            output width (max-w-4xl) so the input doesn't sprawl past
+            the command output above it on wide monitors. The outer
+            border-t still spans full viewport so the divider line
+            extends edge-to-edge. */}
         <div className="border-t border-terminal-green/30 p-2 sm:p-4">
+          <div className="max-w-4xl">
           {/* Right prompt: subtle, only shown when something to say */}
           <div className="flex items-center justify-end mb-0.5 font-mono text-[10px] sm:text-[11px] tabular-nums text-tui-muted h-3 sm:h-4">
             {lastExitCode !== null && (
@@ -781,6 +787,7 @@ function Terminal({ onSwitchToGUI }: TerminalProps) {
                 </div>
               )}
             </div>
+          </div>
           </div>
         </div>
 

--- a/client/src/components/Terminal.tsx
+++ b/client/src/components/Terminal.tsx
@@ -7,6 +7,7 @@ import { usePWA, useURLCommand } from '../hooks/usePWA';
 import { uiText, apiConfig, getSavedTheme } from '../config';
 import { StatusBar } from './tui/StatusBar';
 import { CommandPalette } from './tui/CommandPalette';
+import { TerminalLinkProvider } from './tui/LinkRegistry';
 
 interface TerminalProps {
   onSwitchToGUI?: () => void;
@@ -57,6 +58,7 @@ function Terminal({ onSwitchToGUI }: TerminalProps) {
     historyLength,
     getCommandMetadata,
     recentCommands,
+    linkRegistry,
   } = useTerminal({ portfolioData: portfolioData || null, onSwitchToGUI });
 
   const [paletteOpen, setPaletteOpen] = useState(false);
@@ -245,6 +247,22 @@ function Terminal({ onSwitchToGUI }: TerminalProps) {
       case 'Enter':
         e.preventDefault();
         if (input.trim()) {
+          // Vim-motion link open: `o N` / `g N` / `open N` routes to
+          // the numbered-link registry, not to executeCommand. Falls
+          // through to executeCommand when the input doesn't match.
+          const openMatch = input.trim().match(/^(?:o|g|open)\s+(\d+)$/i);
+          if (openMatch) {
+            const n = parseInt(openMatch[1], 10);
+            const link = linkRegistry.resolve(n);
+            if (link) {
+              window.open(link.href, '_blank', 'noopener,noreferrer');
+            } else {
+              executeCommand(`echo "no link #${n} in view"`);
+            }
+            setInput('');
+            setShowAutocomplete(false);
+            break;
+          }
           executeCommand(input);
           setInput('');
         }
@@ -387,21 +405,25 @@ function Terminal({ onSwitchToGUI }: TerminalProps) {
           onClick={handleTerminalClick}
         >
 
-          {/* Command Output */}
-          <div className="space-y-1 text-xs sm:text-sm lg:text-base">
-            {lines.map((line) => (
-              <motion.div
-                key={line.id}
-                data-line-id={line.id}
-                initial={prefersReducedMotion ? false : { opacity: 0 }}
-                animate={{ opacity: 1 }}
-                transition={{ duration: 0.15, ease: 'easeOut' }}
-                className={`${line.className || 'text-terminal-green'} break-words overflow-x-auto leading-relaxed`}
-              >
-                {line.content}
-              </motion.div>
-            ))}
-          </div>
+          {/* Command Output. TerminalLinkProvider is scoped to this
+              subtree so every NumberedLink inside any Block registers
+              with the same terminal-wide numbering sequence. */}
+          <TerminalLinkProvider value={linkRegistry}>
+            <div className="space-y-1 text-xs sm:text-sm lg:text-base">
+              {lines.map((line) => (
+                <motion.div
+                  key={line.id}
+                  data-line-id={line.id}
+                  initial={prefersReducedMotion ? false : { opacity: 0 }}
+                  animate={{ opacity: 1 }}
+                  transition={{ duration: 0.15, ease: 'easeOut' }}
+                  className={`${line.className || 'text-terminal-green'} break-words overflow-x-auto leading-relaxed`}
+                >
+                  {line.content}
+                </motion.div>
+              ))}
+            </div>
+          </TerminalLinkProvider>
         </div>
 
         {/* Command Input — Starship-style prompt with right-aligned

--- a/client/src/components/Terminal.tsx
+++ b/client/src/components/Terminal.tsx
@@ -5,6 +5,7 @@ import { useTerminal } from '../hooks/useTerminal';
 import { loadPortfolioData } from '../lib/portfolioDataLoader';
 import { usePWA, useURLCommand } from '../hooks/usePWA';
 import { uiText, apiConfig, getSavedTheme } from '../config';
+import { StatusBar } from './tui/StatusBar';
 
 interface TerminalProps {
   onSwitchToGUI?: () => void;
@@ -52,6 +53,7 @@ function Terminal({ onSwitchToGUI }: TerminalProps) {
     lastExitCode,
     promptUser,
     promptHost,
+    historyLength,
   } = useTerminal({ portfolioData: portfolioData || null, onSwitchToGUI });
 
   // Get current suggestions
@@ -481,6 +483,13 @@ function Terminal({ onSwitchToGUI }: TerminalProps) {
             </div>
           </div>
         </div>
+
+        {/* Persistent keyboard-hint status bar (lazygit / k9s / Ghostty) */}
+        <StatusBar
+          themeName={getSavedTheme().name.toLowerCase()}
+          blockCount={lines.filter((l) => l.isCommand).length}
+          historyCount={historyLength}
+        />
       </div>
     </div>
   );

--- a/client/src/components/Terminal.tsx
+++ b/client/src/components/Terminal.tsx
@@ -6,6 +6,7 @@ import { loadPortfolioData } from '../lib/portfolioDataLoader';
 import { usePWA, useURLCommand } from '../hooks/usePWA';
 import { uiText, apiConfig, getSavedTheme } from '../config';
 import { StatusBar } from './tui/StatusBar';
+import { CommandPalette } from './tui/CommandPalette';
 
 interface TerminalProps {
   onSwitchToGUI?: () => void;
@@ -54,7 +55,11 @@ function Terminal({ onSwitchToGUI }: TerminalProps) {
     promptUser,
     promptHost,
     historyLength,
+    getCommandMetadata,
+    recentCommands,
   } = useTerminal({ portfolioData: portfolioData || null, onSwitchToGUI });
+
+  const [paletteOpen, setPaletteOpen] = useState(false);
 
   // Get current suggestions
   const suggestions = getCommandSuggestions(input);
@@ -93,6 +98,20 @@ function Terminal({ onSwitchToGUI }: TerminalProps) {
     document.addEventListener('mousedown', onDocMouseDown);
     return () => document.removeEventListener('mousedown', onDocMouseDown);
   }, [showAutocomplete]);
+
+  // Ctrl+K / Cmd+K opens the command palette from anywhere in the TUI.
+  // Captured at the window level so it works when focus is in a link
+  // or a button inside a Block output.
+  useEffect(() => {
+    const onKey = (e: KeyboardEvent) => {
+      if ((e.ctrlKey || e.metaKey) && (e.key === 'k' || e.key === 'K')) {
+        e.preventDefault();
+        setPaletteOpen((p) => !p);
+      }
+    };
+    window.addEventListener('keydown', onKey);
+    return () => window.removeEventListener('keydown', onKey);
+  }, []);
 
   // Auto-focus input and scroll to bottom
   useEffect(() => {
@@ -489,8 +508,18 @@ function Terminal({ onSwitchToGUI }: TerminalProps) {
           themeName={getSavedTheme().name.toLowerCase()}
           blockCount={lines.filter((l) => l.isCommand).length}
           historyCount={historyLength}
+          mode={paletteOpen ? 'palette' : 'insert'}
         />
       </div>
+
+      {/* Warp-style command palette — Ctrl+K / Cmd+K */}
+      <CommandPalette
+        open={paletteOpen}
+        onClose={() => setPaletteOpen(false)}
+        commands={getCommandMetadata()}
+        recentCommands={recentCommands}
+        onExecute={executeCommand}
+      />
     </div>
   );
 }

--- a/client/src/components/Terminal.tsx
+++ b/client/src/components/Terminal.tsx
@@ -161,11 +161,11 @@ function Terminal({ onSwitchToGUI }: TerminalProps) {
   // Handle offline/online status
   useEffect(() => {
     const handleOffline = () => {
-      executeCommand('echo "⚠️  You are offline. Some features may be unavailable."');
+      executeCommand('echo "[offline] some features unavailable."');
     };
 
     const handleOnline = () => {
-      executeCommand('echo "✅ You are back online!"');
+      executeCommand('echo "[online] connection restored."');
     };
 
     window.addEventListener('offline', handleOffline);
@@ -336,18 +336,18 @@ function Terminal({ onSwitchToGUI }: TerminalProps) {
             <span className="text-xs sm:text-sm truncate">~/portfolio</span>
           </div>
           <div className="flex items-center space-x-2 text-xs opacity-60">
-            {isInstalled && <span className="hidden sm:block">PWA</span>}
+            {isInstalled && <span className="hidden sm:block font-mono">pwa</span>}
             {isInstallable && (
               <button
                 onClick={installApp}
-                className="text-terminal-green hover:text-terminal-bright-green transition-colors p-2 min-w-[44px] min-h-[44px] flex items-center justify-center"
-                title="Install app"
-                aria-label="Install app as PWA"
+                className="text-tui-accent-dim hover:text-terminal-bright-green transition-colors px-2 py-1 min-h-[36px] flex items-center justify-center text-xs font-mono border border-tui-accent-dim/40 hover:border-terminal-bright-green"
+                title="install app"
+                aria-label="install app as pwa"
               >
-                📱
+                [install]
               </button>
             )}
-            <span className="hidden sm:block">Terminal Portfolio v2.0</span>
+            <span className="hidden sm:block font-mono">terminal portfolio v2.0</span>
           </div>
         </div>
 

--- a/client/src/components/Terminal.tsx
+++ b/client/src/components/Terminal.tsx
@@ -4,7 +4,7 @@ import { useQuery } from '@tanstack/react-query';
 import { useTerminal } from '../hooks/useTerminal';
 import { loadPortfolioData } from '../lib/portfolioDataLoader';
 import { usePWA, useURLCommand } from '../hooks/usePWA';
-import { uiText, apiConfig, getSavedTheme } from '../config';
+import { uiText, apiConfig, getSavedTheme, colorThemes } from '../config';
 import { StatusBar } from './tui/StatusBar';
 import { CommandPalette } from './tui/CommandPalette';
 import { TerminalLinkProvider } from './tui/LinkRegistry';
@@ -120,19 +120,95 @@ function Terminal({ onSwitchToGUI }: TerminalProps) {
     return () => document.removeEventListener('mousedown', onDocMouseDown);
   }, [showAutocomplete]);
 
-  // Ctrl+K / Cmd+K opens the command palette from anywhere in the TUI.
-  // Captured at the window level so it works when focus is in a link
-  // or a button inside a Block output.
+  // Global keyboard shortcuts. Implemented at the window level so they
+  // still fire when focus is on a link / button inside a Block.
+  //
+  // Letter shortcuts (t/g/m) use Alt as the modifier because bare
+  // letters collide with typing commands — pressing `m` to trigger
+  // matrix while the input is focused would eat the first letter of
+  // `matrix` as a command name. Alt prevents that collision while
+  // keeping the shortcut muscle-memory-friendly.
+  //
+  // Non-letter prefixes (?, /, :) are safe as bare keys because they
+  // never start a TUI command word.
   useEffect(() => {
     const onKey = (e: KeyboardEvent) => {
-      if ((e.ctrlKey || e.metaKey) && (e.key === 'k' || e.key === 'K')) {
+      const mod = e.ctrlKey || e.metaKey;
+
+      // Ctrl+K / Cmd+K — command palette toggle. Always fires.
+      if (mod && (e.key === 'k' || e.key === 'K')) {
         e.preventDefault();
         setPaletteOpen((p) => !p);
+        return;
+      }
+
+      // Ctrl+L — clear the terminal. Browser binding this to location
+      // bar is why the input-level handler didn't fire reliably;
+      // capturing here with preventDefault wins.
+      if (mod && (e.key === 'l' || e.key === 'L')) {
+        e.preventDefault();
+        clearTerminal();
+        return;
+      }
+
+      // Alt-letter shortcuts. Match lower-or-upper case.
+      if (e.altKey && !mod) {
+        const k = e.key.toLowerCase();
+        if (k === 't') {
+          e.preventDefault();
+          const current = getSavedTheme();
+          const idx = colorThemes.findIndex((th) => th.key === current.key);
+          const next = colorThemes[(idx + 1) % colorThemes.length];
+          executeCommand(`theme ${next.key}`);
+          return;
+        }
+        if (k === 'g') {
+          e.preventDefault();
+          executeCommand('gui');
+          return;
+        }
+        if (k === 'm') {
+          e.preventDefault();
+          executeCommand('matrix');
+          return;
+        }
+      }
+
+      // Non-letter bare-key prefixes — safe because they never start a
+      // command word. Activate regardless of input focus; on focus they
+      // still get to seed the input helpfully.
+      if (!mod && !e.altKey) {
+        if (e.key === '?') {
+          e.preventDefault();
+          executeCommand('help');
+          return;
+        }
+        if (e.key === '/') {
+          e.preventDefault();
+          inputRef.current?.focus();
+          setInput('search ');
+          return;
+        }
+        if (e.key === ':') {
+          // Only seed `:` when the input is empty — otherwise the user
+          // might be trying to type `:` mid-text.
+          const target = e.target as HTMLElement | null;
+          const isEditable =
+            target instanceof HTMLInputElement ||
+            target instanceof HTMLTextAreaElement ||
+            target?.isContentEditable;
+          if (!isEditable || !input) {
+            e.preventDefault();
+            inputRef.current?.focus();
+            setInput(':');
+            return;
+          }
+        }
       }
     };
     window.addEventListener('keydown', onKey);
     return () => window.removeEventListener('keydown', onKey);
-  }, []);
+  }, [clearTerminal, executeCommand, input]);
 
   // Auto-focus input and scroll to bottom
   useEffect(() => {
@@ -208,19 +284,30 @@ function Terminal({ onSwitchToGUI }: TerminalProps) {
     welcomeMessageShown.current = true; // Mark as shown
   }, [urlCommand, isLoading, portfolioData, executeCommand, clearCommand, showWelcomeMessage, bootDone]);
 
-  // Idle matrix rain: after 30s of no input / pointer activity, the
-  // screensaver kicks in. Any interaction dismisses it instantly and
-  // resets the timer. The `matrix` command also triggers it directly
-  // (handled in useTerminal; listens for a state signal here).
+  // Idle matrix rain:
+  //   - After 30s of no activity the screensaver activates.
+  //   - Any interaction WHILE ACTIVE dismisses it.
+  //   - Interaction while idle just resets the 30s timer (does not
+  //     spuriously set active=false; earlier version did, which racing
+  //     with the `matrix` command caused the rain to vanish the same
+  //     frame it was summoned).
+  //   - The `matrix` command manually triggers it via onTriggerMatrix.
+  const matrixActiveRef = useRef(false);
+  matrixActiveRef.current = matrixActive;
   useEffect(() => {
     const IDLE_MS = 30_000;
     let t: ReturnType<typeof setTimeout>;
-    const schedule = () => {
-      setMatrixActive(false);
+    const resetTimer = () => {
       clearTimeout(t);
       t = setTimeout(() => setMatrixActive(true), IDLE_MS);
     };
-    schedule();
+    const handle = () => {
+      if (matrixActiveRef.current) {
+        setMatrixActive(false);
+      }
+      resetTimer();
+    };
+    resetTimer();
     const evts: (keyof WindowEventMap)[] = [
       'keydown',
       'pointerdown',
@@ -228,10 +315,10 @@ function Terminal({ onSwitchToGUI }: TerminalProps) {
       'wheel',
       'touchstart',
     ];
-    evts.forEach((e) => window.addEventListener(e, schedule, { passive: true }));
+    evts.forEach((e) => window.addEventListener(e, handle, { passive: true }));
     return () => {
       clearTimeout(t);
-      evts.forEach((e) => window.removeEventListener(e, schedule));
+      evts.forEach((e) => window.removeEventListener(e, handle));
     };
   }, []);
 
@@ -378,22 +465,10 @@ function Terminal({ onSwitchToGUI }: TerminalProps) {
       case 'Enter':
         e.preventDefault();
         if (input.trim()) {
-          // Vim-motion link open: `o N` / `g N` / `open N` routes to
-          // the numbered-link registry, not to executeCommand. Falls
-          // through to executeCommand when the input doesn't match.
-          const openMatch = input.trim().match(/^(?:o|g|open)\s+(\d+)$/i);
-          if (openMatch) {
-            const n = parseInt(openMatch[1], 10);
-            const link = linkRegistry.resolve(n);
-            if (link) {
-              window.open(link.href, '_blank', 'noopener,noreferrer');
-            } else {
-              executeCommand(`echo "no link #${n} in view"`);
-            }
-            setInput('');
-            setShowAutocomplete(false);
-            break;
-          }
+          // `o N` / `g N` / `open N` are handled as first-class commands
+          // inside useTerminal's executeCommand — they route through the
+          // link registry there, so history + prompt echo + exit codes
+          // all behave normally.
           executeCommand(input);
           setInput('');
         }
@@ -501,6 +576,10 @@ function Terminal({ onSwitchToGUI }: TerminalProps) {
       {/* Shared film-grain atmosphere — also used by the GUI so both
            views share one noise floor. Paused on reduced-motion. */}
       <div className="film-grain" aria-hidden="true" />
+      {/* Idle matrix-rain screensaver — positioned on the outer shell
+           (not the scrolling output pane) so it overlays the full
+           terminal viewport regardless of scroll position. */}
+      <IdleMatrixRain active={matrixActive} />
       <div className="flex flex-col h-full">
         {/* Terminal Header — traffic-light dots keep the retro chrome,
              and the path segment now reflects the Starship-style dir. */}
@@ -555,9 +634,6 @@ function Terminal({ onSwitchToGUI }: TerminalProps) {
               }}
             />
           )}
-          {/* Idle matrix-rain screensaver — overlays output while idle. */}
-          <IdleMatrixRain active={matrixActive} />
-
           {/* Command Output. TerminalLinkProvider is scoped to this
               subtree so every NumberedLink inside any Block registers
               with the same terminal-wide numbering sequence. */}

--- a/client/src/components/Terminal.tsx
+++ b/client/src/components/Terminal.tsx
@@ -4,7 +4,7 @@ import { useQuery } from '@tanstack/react-query';
 import { useTerminal } from '../hooks/useTerminal';
 import { loadPortfolioData } from '../lib/portfolioDataLoader';
 import { usePWA, useURLCommand } from '../hooks/usePWA';
-import { getPromptString, uiText, apiConfig } from '../config';
+import { uiText, apiConfig, getSavedTheme } from '../config';
 
 interface TerminalProps {
   onSwitchToGUI?: () => void;
@@ -48,6 +48,10 @@ function Terminal({ onSwitchToGUI }: TerminalProps) {
     getAllCommands,
     clearTerminal,
     showWelcomeMessage,
+    currentDir,
+    lastExitCode,
+    promptUser,
+    promptHost,
   } = useTerminal({ portfolioData: portfolioData || null, onSwitchToGUI });
 
   // Get current suggestions
@@ -379,10 +383,29 @@ function Terminal({ onSwitchToGUI }: TerminalProps) {
           </div>
         </div>
 
-        {/* Command Input */}
+        {/* Command Input — Starship-style prompt with right-aligned
+            exit-status + theme name. Dir changes with navigation commands. */}
         <div className="border-t border-terminal-green/30 p-2 sm:p-4">
-          <div className="flex items-center">
-            <span className="text-terminal-bright-green mr-1 sm:mr-2 text-xs sm:text-sm flex-shrink-0">{getPromptString()}</span>
+          {/* Right prompt: subtle, only shown when something to say */}
+          <div className="flex items-center justify-end mb-0.5 font-mono text-[10px] sm:text-[11px] tabular-nums text-tui-muted h-3 sm:h-4">
+            {lastExitCode !== null && (
+              <span className="mr-3">
+                {lastExitCode === 0 ? (
+                  <span className="text-terminal-bright-green">✔</span>
+                ) : (
+                  <span className="text-tui-error">✖ {lastExitCode}</span>
+                )}
+              </span>
+            )}
+            <span>{getSavedTheme().name.toLowerCase()}</span>
+          </div>
+          <div className="flex items-center font-mono">
+            <span className="flex-shrink-0 text-xs sm:text-sm whitespace-nowrap">
+              <span className="text-tui-accent-dim">{promptUser}</span>
+              <span className="text-tui-muted">@{promptHost}</span>
+              <span className="text-terminal-bright-green"> {currentDir}</span>
+              <span className="text-terminal-green"> $ </span>
+            </span>
             <div className="flex-1 relative min-w-0">
               <input
                 ref={inputRef}

--- a/client/src/components/Terminal.tsx
+++ b/client/src/components/Terminal.tsx
@@ -8,6 +8,8 @@ import { uiText, apiConfig, getSavedTheme } from '../config';
 import { StatusBar } from './tui/StatusBar';
 import { CommandPalette } from './tui/CommandPalette';
 import { TerminalLinkProvider } from './tui/LinkRegistry';
+import { BootSequence } from './tui/BootSequence';
+import { IdleMatrixRain } from './tui/IdleMatrixRain';
 
 interface TerminalProps {
   onSwitchToGUI?: () => void;
@@ -59,13 +61,26 @@ function Terminal({ onSwitchToGUI }: TerminalProps) {
     getCommandMetadata,
     recentCommands,
     linkRegistry,
-  } = useTerminal({ portfolioData: portfolioData || null, onSwitchToGUI });
+  } = useTerminal({
+    portfolioData: portfolioData || null,
+    onSwitchToGUI,
+    onTriggerMatrix: () => setMatrixActive(true),
+  });
 
   const [paletteOpen, setPaletteOpen] = useState(false);
   // Reverse-search state (fzf / bash Ctrl+R).
   const [searchMode, setSearchMode] = useState(false);
   const [searchQuery, setSearchQuery] = useState('');
   const [searchMatchIndex, setSearchMatchIndex] = useState(0);
+  // Boot sequence: shown once per tab session. sessionStorage flag
+  // short-circuits on reloads so only the very first mount plays it.
+  const [bootDone, setBootDone] = useState(() => {
+    if (typeof window === 'undefined') return true;
+    if (new URLSearchParams(window.location.search).has('skipBoot')) return true;
+    return sessionStorage.getItem('tui-boot-shown') === '1';
+  });
+  // Idle matrix-rain screensaver: fires after 30s with no input.
+  const [matrixActive, setMatrixActive] = useState(false);
 
   // Get current suggestions
   const suggestions = getCommandSuggestions(input);
@@ -171,11 +186,15 @@ function Terminal({ onSwitchToGUI }: TerminalProps) {
     lastAnchoredCommandId.current = lastCmd.id;
   }, [lines, prefersReducedMotion]);
 
-  // Handle URL command execution (for PWA shortcuts)
+  // Handle URL command execution (for PWA shortcuts). Waits for the
+  // boot sequence to finish — bootDone flips true after the CRT
+  // animation, so the welcome / deep-link runs against the rendered
+  // Block chrome rather than behind the boot overlay.
   useEffect(() => {
     if (isLoading || !portfolioData || welcomeMessageShown.current) {
       return; // Wait for data, and only run once
     }
+    if (!bootDone) return; // Wait for boot sequence to finish
 
     if (urlCommand) {
       // If a command is in the URL, execute it and skip the welcome message
@@ -187,7 +206,34 @@ function Terminal({ onSwitchToGUI }: TerminalProps) {
     }
 
     welcomeMessageShown.current = true; // Mark as shown
-  }, [urlCommand, isLoading, portfolioData, executeCommand, clearCommand, showWelcomeMessage]);
+  }, [urlCommand, isLoading, portfolioData, executeCommand, clearCommand, showWelcomeMessage, bootDone]);
+
+  // Idle matrix rain: after 30s of no input / pointer activity, the
+  // screensaver kicks in. Any interaction dismisses it instantly and
+  // resets the timer. The `matrix` command also triggers it directly
+  // (handled in useTerminal; listens for a state signal here).
+  useEffect(() => {
+    const IDLE_MS = 30_000;
+    let t: ReturnType<typeof setTimeout>;
+    const schedule = () => {
+      setMatrixActive(false);
+      clearTimeout(t);
+      t = setTimeout(() => setMatrixActive(true), IDLE_MS);
+    };
+    schedule();
+    const evts: (keyof WindowEventMap)[] = [
+      'keydown',
+      'pointerdown',
+      'pointermove',
+      'wheel',
+      'touchstart',
+    ];
+    evts.forEach((e) => window.addEventListener(e, schedule, { passive: true }));
+    return () => {
+      clearTimeout(t);
+      evts.forEach((e) => window.removeEventListener(e, schedule));
+    };
+  }, []);
 
   // Handle offline/online status
   useEffect(() => {
@@ -486,9 +532,25 @@ function Terminal({ onSwitchToGUI }: TerminalProps) {
           aria-label="Terminal output"
           aria-live="polite"
           aria-atomic="false"
-          className="flex-1 p-2 sm:p-4 overflow-y-auto scrollbar-terminal cursor-text"
+          className="flex-1 p-2 sm:p-4 overflow-y-auto scrollbar-terminal cursor-text relative"
           onClick={handleTerminalClick}
         >
+          {/* CRT boot sequence — plays once per session before welcome. */}
+          {!bootDone && (
+            <BootSequence
+              themeName={getSavedTheme().name.toLowerCase()}
+              onComplete={() => {
+                setBootDone(true);
+                try {
+                  sessionStorage.setItem('tui-boot-shown', '1');
+                } catch {
+                  // ignore storage errors
+                }
+              }}
+            />
+          )}
+          {/* Idle matrix-rain screensaver — overlays output while idle. */}
+          <IdleMatrixRain active={matrixActive} />
 
           {/* Command Output. TerminalLinkProvider is scoped to this
               subtree so every NumberedLink inside any Block registers

--- a/client/src/components/Terminal.tsx
+++ b/client/src/components/Terminal.tsx
@@ -1,4 +1,4 @@
-import { useState, useRef, useEffect, useLayoutEffect, useCallback, memo } from 'react';
+import { useState, useRef, useEffect, useLayoutEffect, useCallback, useMemo, memo } from 'react';
 import { motion, useReducedMotion } from 'framer-motion';
 import { useQuery } from '@tanstack/react-query';
 import { useTerminal } from '../hooks/useTerminal';
@@ -64,7 +64,14 @@ function Terminal({ onSwitchToGUI }: TerminalProps) {
   } = useTerminal({
     portfolioData: portfolioData || null,
     onSwitchToGUI,
-    onTriggerMatrix: () => setMatrixActive(true),
+    onTriggerMatrix: (opts) => {
+      setMatrixActive(true);
+      setMatrixPersistent(opts?.persist === true);
+    },
+    onDismissMatrix: () => {
+      setMatrixActive(false);
+      setMatrixPersistent(false);
+    },
   });
 
   const [paletteOpen, setPaletteOpen] = useState(false);
@@ -80,24 +87,56 @@ function Terminal({ onSwitchToGUI }: TerminalProps) {
     return sessionStorage.getItem('tui-boot-shown') === '1';
   });
   // Idle matrix-rain screensaver: fires after 30s with no input.
+  // `matrixPersistent` keeps the rain on across keypresses (`matrix on`)
+  // until explicitly dismissed via `matrix off`. Default mode auto-
+  // dismisses on user interaction.
   const [matrixActive, setMatrixActive] = useState(false);
+  const [matrixPersistent, setMatrixPersistent] = useState(false);
 
-  // Get current suggestions
-  const suggestions = getCommandSuggestions(input);
+  // Persistent silent toggle for Alt+M / the matrix chip. We bypass
+  // executeCommand entirely — no prompt echo, no scrollback line, no
+  // history pollution — and pin it persistent so the next keypress
+  // doesn't immediately dismiss it. The typed `matrix` / `matrix on`
+  // / `matrix off` commands still go through the normal pathway.
+  const toggleMatrix = useCallback(() => {
+    setMatrixActive((wasActive) => {
+      if (wasActive) {
+        setMatrixPersistent(false);
+        return false;
+      }
+      setMatrixPersistent(true);
+      return true;
+    });
+  }, []);
+
+  // Get current suggestions. Memoised so the array reference is stable
+  // across renders that don't change `input` — without this, the
+  // autocomplete effect would re-fire on every render (the arrow-key
+  // bump → re-render path), wiping `selectedSuggestion` back to 0 and
+  // breaking ↑/↓ navigation inside the dropdown.
+  const suggestions = useMemo(
+    () => getCommandSuggestions(input),
+    [getCommandSuggestions, input],
+  );
 
   // Update autocomplete visibility and reset selection when input changes.
   // Suppressed while browsing history with arrow keys — otherwise a recalled
   // command (e.g. "skills") opens the autocomplete, and the very next Up
   // goes into autocomplete navigation rather than continuing history recall.
+  // Also suppressed when the only suggestion exactly matches the input —
+  // a one-row dropdown showing what you already typed is just noise.
   useEffect(() => {
-    if (!isBrowsingHistory && suggestions.length > 0 && input.trim()) {
+    const trimmed = input.trim();
+    const isRedundant =
+      suggestions.length === 1 && suggestions[0].toLowerCase() === trimmed.toLowerCase();
+    if (!isBrowsingHistory && suggestions.length > 0 && trimmed && !isRedundant) {
       setShowAutocomplete(true);
       setSelectedSuggestion(0);
     } else {
       setShowAutocomplete(false);
       setSelectedSuggestion(0);
     }
-  }, [input, suggestions.length, isBrowsingHistory]);
+  }, [input, suggestions, isBrowsingHistory]);
 
   // Measure the ghost span to position the blinking cursor precisely.
   // Runs before paint so the cursor never flashes at the wrong spot.
@@ -151,10 +190,13 @@ function Terminal({ onSwitchToGUI }: TerminalProps) {
         return;
       }
 
-      // Alt-letter shortcuts. Match lower-or-upper case.
+      // Alt-letter shortcuts. Match by physical key code (e.code) not
+      // produced character (e.key) — on macOS Alt is the Option key,
+      // which mutates `e.key` to special chars (Alt+T → "†", Alt+G →
+      // "©", Alt+M → "µ"). e.code === "KeyT" identifies the same
+      // physical key regardless of the modifier-mutated character.
       if (e.altKey && !mod) {
-        const k = e.key.toLowerCase();
-        if (k === 't') {
+        if (e.code === 'KeyT') {
           e.preventDefault();
           const current = getSavedTheme();
           const idx = colorThemes.findIndex((th) => th.key === current.key);
@@ -162,42 +204,49 @@ function Terminal({ onSwitchToGUI }: TerminalProps) {
           executeCommand(`theme ${next.key}`);
           return;
         }
-        if (k === 'g') {
+        if (e.code === 'KeyG') {
           e.preventDefault();
           executeCommand('gui');
           return;
         }
-        if (k === 'm') {
+        if (e.code === 'KeyM') {
           e.preventDefault();
-          executeCommand('matrix');
+          toggleMatrix();
           return;
         }
       }
 
-      // Non-letter bare-key prefixes — safe because they never start a
-      // command word. Activate regardless of input focus; on focus they
-      // still get to seed the input helpfully.
+      // Non-letter bare-key prefixes. These previously hijacked the
+      // input regardless of state, which broke things like typing
+      // `rm -rf` then `/` (suddenly the input became `search `).
+      // Now we only intercept when the input is empty — at that point
+      // the user clearly isn't typing a command, so the shortcut wins.
+      // While typing a command, these keys reach the input naturally
+      // (`/` is a valid character in arguments).
       if (!mod && !e.altKey) {
+        const target = e.target as HTMLElement | null;
+        const isEditable =
+          target instanceof HTMLInputElement ||
+          target instanceof HTMLTextAreaElement ||
+          target?.isContentEditable;
+        const inputEmpty = !input;
         if (e.key === '?') {
-          e.preventDefault();
-          executeCommand('help');
-          return;
+          if (!isEditable || inputEmpty) {
+            e.preventDefault();
+            executeCommand('help');
+            return;
+          }
         }
         if (e.key === '/') {
-          e.preventDefault();
-          inputRef.current?.focus();
-          setInput('search ');
-          return;
+          if (!isEditable || inputEmpty) {
+            e.preventDefault();
+            inputRef.current?.focus();
+            setInput('search ');
+            return;
+          }
         }
         if (e.key === ':') {
-          // Only seed `:` when the input is empty — otherwise the user
-          // might be trying to type `:` mid-text.
-          const target = e.target as HTMLElement | null;
-          const isEditable =
-            target instanceof HTMLInputElement ||
-            target instanceof HTMLTextAreaElement ||
-            target?.isContentEditable;
-          if (!isEditable || !input) {
+          if (!isEditable || inputEmpty) {
             e.preventDefault();
             inputRef.current?.focus();
             setInput(':');
@@ -208,7 +257,7 @@ function Terminal({ onSwitchToGUI }: TerminalProps) {
     };
     window.addEventListener('keydown', onKey);
     return () => window.removeEventListener('keydown', onKey);
-  }, [clearTerminal, executeCommand, input]);
+  }, [clearTerminal, executeCommand, input, toggleMatrix]);
 
   // Auto-focus input and scroll to bottom
   useEffect(() => {
@@ -286,39 +335,59 @@ function Terminal({ onSwitchToGUI }: TerminalProps) {
 
   // Idle matrix rain:
   //   - After 30s of no activity the screensaver activates.
-  //   - Any interaction WHILE ACTIVE dismisses it.
-  //   - Interaction while idle just resets the 30s timer (does not
-  //     spuriously set active=false; earlier version did, which racing
-  //     with the `matrix` command caused the rain to vanish the same
-  //     frame it was summoned).
-  //   - The `matrix` command manually triggers it via onTriggerMatrix.
+  //   - Deliberate user input WHILE ACTIVE dismisses it. We split
+  //     "dismissal" (keydown / pointerdown / wheel / touchstart) from
+  //     "idle reset" (those + pointermove). pointermove resets the
+  //     idle clock but does NOT dismiss — otherwise reading the screen
+  //     while your mouse drifts a pixel kills the rain.
+  //   - There's a 350ms grace period after activation during which
+  //     dismissal is ignored. This stops the very keydown that
+  //     triggered `matrix` (the Enter key) from immediately dismissing
+  //     it via the window-level listener firing later in the same
+  //     event dispatch.
+  //   - The `matrix` command manually triggers via onTriggerMatrix.
   const matrixActiveRef = useRef(false);
   matrixActiveRef.current = matrixActive;
+  const matrixPersistentRef = useRef(false);
+  matrixPersistentRef.current = matrixPersistent;
+  const matrixActivatedAt = useRef(0);
+  useEffect(() => {
+    if (matrixActive) matrixActivatedAt.current = Date.now();
+  }, [matrixActive]);
   useEffect(() => {
     const IDLE_MS = 30_000;
+    const GRACE_MS = 350;
     let t: ReturnType<typeof setTimeout>;
     const resetTimer = () => {
       clearTimeout(t);
       t = setTimeout(() => setMatrixActive(true), IDLE_MS);
     };
-    const handle = () => {
-      if (matrixActiveRef.current) {
+    const dismiss = () => {
+      if (matrixPersistentRef.current) return; // `matrix on` mode — keep rain alive
+      if (matrixActiveRef.current && Date.now() - matrixActivatedAt.current > GRACE_MS) {
         setMatrixActive(false);
       }
-      resetTimer();
     };
     resetTimer();
-    const evts: (keyof WindowEventMap)[] = [
+    const idleEvts: (keyof WindowEventMap)[] = [
       'keydown',
       'pointerdown',
       'pointermove',
       'wheel',
       'touchstart',
     ];
-    evts.forEach((e) => window.addEventListener(e, handle, { passive: true }));
+    const dismissEvts: (keyof WindowEventMap)[] = [
+      'keydown',
+      'pointerdown',
+      'wheel',
+      'touchstart',
+    ];
+    idleEvts.forEach((e) => window.addEventListener(e, resetTimer, { passive: true }));
+    dismissEvts.forEach((e) => window.addEventListener(e, dismiss, { passive: true }));
     return () => {
       clearTimeout(t);
-      evts.forEach((e) => window.removeEventListener(e, handle));
+      idleEvts.forEach((e) => window.removeEventListener(e, resetTimer));
+      dismissEvts.forEach((e) => window.removeEventListener(e, dismiss));
     };
   }, []);
 
@@ -638,7 +707,7 @@ function Terminal({ onSwitchToGUI }: TerminalProps) {
               subtree so every NumberedLink inside any Block registers
               with the same terminal-wide numbering sequence. */}
           <TerminalLinkProvider value={linkRegistry}>
-            <div className="space-y-1 text-xs sm:text-sm lg:text-base">
+            <div className="space-y-1 text-sm sm:text-base">
               {lines.map((line) => (
                 <motion.div
                   key={line.id}
@@ -655,31 +724,17 @@ function Terminal({ onSwitchToGUI }: TerminalProps) {
           </TerminalLinkProvider>
         </div>
 
-        {/* Command Input — Starship-style prompt with right-aligned
-            exit-status + theme name. Dir changes with navigation
-            commands. Inner content is constrained to match the Block
-            output width (max-w-4xl) so the input doesn't sprawl past
-            the command output above it on wide monitors. The outer
-            border-t still spans full viewport so the divider line
-            extends edge-to-edge. */}
-        <div className="border-t border-terminal-green/30 p-2 sm:p-4">
+        {/* Command Input — Starship-style prompt. Exit status is a
+            single inline ✔/✖ glyph between the path and the `$`, so
+            we don't need a dedicated row above. Theme name is shown
+            once in the StatusBar instead of duplicated here. Inner
+            content is capped to max-w-4xl to align with Block output
+            on wide monitors; the outer border-t still spans edge-to-edge. */}
+        <div className="border-t border-terminal-green/30 px-2 sm:px-4 py-1.5 sm:py-2">
           <div className="max-w-4xl">
-          {/* Right prompt: subtle, only shown when something to say */}
-          <div className="flex items-center justify-end mb-0.5 font-mono text-[10px] sm:text-[11px] tabular-nums text-tui-muted h-3 sm:h-4">
-            {lastExitCode !== null && (
-              <span className="mr-3">
-                {lastExitCode === 0 ? (
-                  <span className="text-terminal-bright-green">✔</span>
-                ) : (
-                  <span className="text-tui-error">✖ {lastExitCode}</span>
-                )}
-              </span>
-            )}
-            <span>{getSavedTheme().name.toLowerCase()}</span>
-          </div>
           <div className="flex items-center font-mono">
             {searchMode ? (
-              <span className="flex-shrink-0 text-xs sm:text-sm whitespace-nowrap">
+              <span className="flex-shrink-0 text-sm sm:text-base whitespace-nowrap">
                 <span className="text-tui-accent-dim">(reverse-i-search)</span>
                 <span className="text-tui-muted">`</span>
                 <span className="text-terminal-bright-green">{searchQuery}</span>
@@ -687,14 +742,21 @@ function Terminal({ onSwitchToGUI }: TerminalProps) {
                 <span className="text-terminal-green">: </span>
               </span>
             ) : (
-              <span className="flex-shrink-0 text-xs sm:text-sm whitespace-nowrap">
+              <span className="flex-shrink-0 text-sm sm:text-base whitespace-nowrap">
                 <span className="text-tui-accent-dim">{promptUser}</span>
                 <span className="text-tui-muted">@{promptHost}</span>
                 <span className="text-terminal-bright-green"> {currentDir}</span>
+                {lastExitCode !== null && (
+                  lastExitCode === 0 ? (
+                    <span className="text-terminal-bright-green"> ✔</span>
+                  ) : (
+                    <span className="text-tui-error"> ✖</span>
+                  )
+                )}
                 <span className="text-terminal-green"> $ </span>
               </span>
             )}
-            <div className="flex-1 relative min-w-0">
+            <div className="flex-1 relative min-w-0 ml-1.5 sm:ml-2">
               <input
                 ref={inputRef}
                 type="text"
@@ -708,7 +770,7 @@ function Terminal({ onSwitchToGUI }: TerminalProps) {
                   }
                 }}
                 onKeyDown={handleKeyDown}
-                className="w-full bg-transparent text-terminal-green outline-none font-mono text-xs sm:text-sm"
+                className="w-full bg-transparent text-terminal-green outline-none font-mono text-sm sm:text-base"
                 autoComplete="off"
                 spellCheck="false"
                 placeholder={!hasTyped && !searchMode ? uiText.input.placeholder : ""}
@@ -718,34 +780,20 @@ function Terminal({ onSwitchToGUI }: TerminalProps) {
               <span
                 ref={ghostRef}
                 aria-hidden="true"
-                className="invisible absolute top-0 left-0 whitespace-pre font-mono text-xs sm:text-sm pointer-events-none"
+                className="invisible absolute top-0 left-0 whitespace-pre font-mono text-sm sm:text-base pointer-events-none"
               >
                 {input}
               </span>
               <span
-                className="absolute text-terminal-green blink text-xs sm:text-sm"
+                className="absolute text-terminal-green blink text-sm sm:text-base"
                 style={{ left: `${cursorLeft}px`, top: '50%', transform: 'translateY(-45%)' }}
               >
                 █
               </span>
               
-              {/* Reverse-search hints: shown beneath the prompt while
-                  a Ctrl+R search is active. Hidden otherwise. */}
-              {searchMode && (
-                <div className="absolute top-full left-0 right-0 mt-1 text-[10px] font-mono text-tui-muted flex items-center gap-3">
-                  <span>
-                    {searchMatches.length > 0
-                      ? `${searchMatchIndex + 1}/${searchMatches.length}`
-                      : 'no match'}
-                  </span>
-                  <span>
-                    <span className="text-terminal-bright-green">⌃R</span> next ·{' '}
-                    <span className="text-terminal-bright-green">↵</span> run ·{' '}
-                    <span className="text-terminal-bright-green">tab</span> edit ·{' '}
-                    <span className="text-terminal-bright-green">esc</span> cancel
-                  </span>
-                </div>
-              )}
+              {/* Reverse-search hints live in the StatusBar (mode='search')
+                  so they don't pop in as a third row above the chip
+                  strip. See StatusBar.tsx for the swap. */}
 
               {/* Autocomplete Dropdown */}
               {showAutocomplete && suggestions.length > 0 && (
@@ -761,7 +809,7 @@ function Terminal({ onSwitchToGUI }: TerminalProps) {
                         key={suggestion}
                         role="option"
                         aria-selected={index === selectedSuggestion}
-                        className={`px-3 py-1 text-xs sm:text-sm cursor-pointer border border-transparent rounded-sm transition-all duration-150 ease-in-out ${
+                        className={`px-3 py-1 text-sm sm:text-base cursor-pointer border border-transparent rounded-sm transition-all duration-150 ease-in-out ${
                           index === selectedSuggestion
                             // Selected state — theme-reactive glow via --glow-color-rgb,
                             // so a Glacier theme pops in cool-white and a Pink theme
@@ -791,12 +839,51 @@ function Terminal({ onSwitchToGUI }: TerminalProps) {
           </div>
         </div>
 
-        {/* Persistent keyboard-hint status bar (lazygit / k9s / Ghostty) */}
+        {/* Persistent keyboard-hint status bar (lazygit / k9s / Ghostty).
+            Each chip is also tappable — fires the same action a
+            keyboard shortcut would. On touch devices the modifier
+            chips hide entirely (they have no Ctrl/Alt counterpart),
+            but the bare-key chips (?, /, :) still tap to act. */}
         <StatusBar
           themeName={getSavedTheme().name.toLowerCase()}
           blockCount={lines.filter((l) => l.isCommand).length}
           historyCount={historyLength}
           mode={searchMode ? 'search' : paletteOpen ? 'palette' : 'insert'}
+          searchInfo={
+            searchMode
+              ? { matchIndex: searchMatchIndex, matchCount: searchMatches.length }
+              : undefined
+          }
+          actions={{
+            help: () => executeCommand('help'),
+            search: () => {
+              inputRef.current?.focus();
+              setInput('search ');
+            },
+            cmd: () => {
+              inputRef.current?.focus();
+              setInput(':');
+            },
+            recall: () => {
+              setSearchMode(true);
+              setSearchQuery(input);
+              setSearchMatchIndex(0);
+              setShowAutocomplete(false);
+              inputRef.current?.focus();
+            },
+            palette: () => setPaletteOpen((p) => !p),
+            cycleTheme: () => {
+              const current = getSavedTheme();
+              const idx = colorThemes.findIndex((th) => th.key === current.key);
+              const next = colorThemes[(idx + 1) % colorThemes.length];
+              executeCommand(`theme ${next.key}`);
+            },
+            toGui: () => executeCommand('gui'),
+            // Same toggle as Alt+M — silent (no echo), persistent
+            // (doesn't auto-dismiss on next keypress).
+            matrix: toggleMatrix,
+            clear: () => clearTerminal(),
+          }}
         />
       </div>
 

--- a/client/src/components/Terminal.tsx
+++ b/client/src/components/Terminal.tsx
@@ -1,4 +1,4 @@
-import { useState, useRef, useEffect, useLayoutEffect, memo } from 'react';
+import { useState, useRef, useEffect, useLayoutEffect, useCallback, memo } from 'react';
 import { motion, useReducedMotion } from 'framer-motion';
 import { useQuery } from '@tanstack/react-query';
 import { useTerminal } from '../hooks/useTerminal';
@@ -62,6 +62,10 @@ function Terminal({ onSwitchToGUI }: TerminalProps) {
   } = useTerminal({ portfolioData: portfolioData || null, onSwitchToGUI });
 
   const [paletteOpen, setPaletteOpen] = useState(false);
+  // Reverse-search state (fzf / bash Ctrl+R).
+  const [searchMode, setSearchMode] = useState(false);
+  const [searchQuery, setSearchQuery] = useState('');
+  const [searchMatchIndex, setSearchMatchIndex] = useState(0);
 
   // Get current suggestions
   const suggestions = getCommandSuggestions(input);
@@ -204,8 +208,89 @@ function Terminal({ onSwitchToGUI }: TerminalProps) {
     };
   }, [executeCommand]);
 
+  // Reverse-search: all history entries matching the query, newest
+  // first. An empty query yields every history entry.
+  const searchMatches = searchMode
+    ? recentCommands.filter((cmd) =>
+        searchQuery === '' || cmd.toLowerCase().includes(searchQuery.toLowerCase()),
+      )
+    : [];
+  const activeSearchMatch =
+    searchMatches[Math.min(searchMatchIndex, Math.max(0, searchMatches.length - 1))];
+
+  const exitSearchMode = useCallback((commit?: string | null) => {
+    setSearchMode(false);
+    setSearchQuery('');
+    setSearchMatchIndex(0);
+    if (commit !== undefined && commit !== null) setInput(commit);
+    inputRef.current?.focus();
+  }, []);
+
   // Handle keydown events
   const handleKeyDown = (e: React.KeyboardEvent<HTMLInputElement>) => {
+    // Reverse-search mode absorbs every key — enter/exit are the only
+    // transitions back to normal terminal behaviour.
+    if (searchMode) {
+      if (e.key === 'Escape' || (e.key === 'g' && e.ctrlKey)) {
+        e.preventDefault();
+        exitSearchMode('');
+        return;
+      }
+      if (e.key === 'Enter') {
+        e.preventDefault();
+        if (activeSearchMatch) {
+          exitSearchMode(null);
+          setInput('');
+          executeCommand(activeSearchMatch);
+        } else {
+          exitSearchMode('');
+        }
+        return;
+      }
+      if (e.ctrlKey && (e.key === 'r' || e.key === 'R')) {
+        e.preventDefault();
+        // Cycle to the next older match.
+        setSearchMatchIndex((i) =>
+          searchMatches.length > 0 ? (i + 1) % searchMatches.length : 0,
+        );
+        return;
+      }
+      if (e.key === 'Tab') {
+        // Commit the match as the current input for editing.
+        e.preventDefault();
+        exitSearchMode(activeSearchMatch ?? '');
+        return;
+      }
+      if (e.key === 'Backspace') {
+        e.preventDefault();
+        setSearchQuery((q) => q.slice(0, -1));
+        setSearchMatchIndex(0);
+        return;
+      }
+      if (e.key.length === 1 && !e.ctrlKey && !e.metaKey && !e.altKey) {
+        e.preventDefault();
+        setSearchQuery((q) => q + e.key);
+        setSearchMatchIndex(0);
+        return;
+      }
+      // Block arrow keys, etc. while searching.
+      if (e.key.startsWith('Arrow')) {
+        e.preventDefault();
+        return;
+      }
+      return;
+    }
+
+    // Ctrl+R enters reverse-search (from normal / autocomplete mode).
+    if (e.ctrlKey && (e.key === 'r' || e.key === 'R')) {
+      e.preventDefault();
+      setSearchMode(true);
+      setSearchQuery(input); // seed with whatever they were typing
+      setSearchMatchIndex(0);
+      setShowAutocomplete(false);
+      return;
+    }
+
     // Handle autocomplete navigation
     if (showAutocomplete && suggestions.length > 0) {
       switch (e.key) {
@@ -443,18 +528,30 @@ function Terminal({ onSwitchToGUI }: TerminalProps) {
             <span>{getSavedTheme().name.toLowerCase()}</span>
           </div>
           <div className="flex items-center font-mono">
-            <span className="flex-shrink-0 text-xs sm:text-sm whitespace-nowrap">
-              <span className="text-tui-accent-dim">{promptUser}</span>
-              <span className="text-tui-muted">@{promptHost}</span>
-              <span className="text-terminal-bright-green"> {currentDir}</span>
-              <span className="text-terminal-green"> $ </span>
-            </span>
+            {searchMode ? (
+              <span className="flex-shrink-0 text-xs sm:text-sm whitespace-nowrap">
+                <span className="text-tui-accent-dim">(reverse-i-search)</span>
+                <span className="text-tui-muted">`</span>
+                <span className="text-terminal-bright-green">{searchQuery}</span>
+                <span className="text-tui-muted">'</span>
+                <span className="text-terminal-green">: </span>
+              </span>
+            ) : (
+              <span className="flex-shrink-0 text-xs sm:text-sm whitespace-nowrap">
+                <span className="text-tui-accent-dim">{promptUser}</span>
+                <span className="text-tui-muted">@{promptHost}</span>
+                <span className="text-terminal-bright-green"> {currentDir}</span>
+                <span className="text-terminal-green"> $ </span>
+              </span>
+            )}
             <div className="flex-1 relative min-w-0">
               <input
                 ref={inputRef}
                 type="text"
-                value={input}
+                value={searchMode ? (activeSearchMatch ?? '') : input}
+                readOnly={searchMode}
                 onChange={(e) => {
+                  if (searchMode) return; // all typing is handled via keydown
                   setInput(e.target.value);
                   if (!hasTyped && e.target.value.length > 0) {
                     setHasTyped(true);
@@ -464,7 +561,7 @@ function Terminal({ onSwitchToGUI }: TerminalProps) {
                 className="w-full bg-transparent text-terminal-green outline-none font-mono text-xs sm:text-sm"
                 autoComplete="off"
                 spellCheck="false"
-                placeholder={!hasTyped ? uiText.input.placeholder : ""}
+                placeholder={!hasTyped && !searchMode ? uiText.input.placeholder : ""}
               />
               {/* Ghost span — invisible mirror of the input text. Its
                   offsetWidth is what we measure to position the cursor. */}
@@ -482,6 +579,24 @@ function Terminal({ onSwitchToGUI }: TerminalProps) {
                 █
               </span>
               
+              {/* Reverse-search hints: shown beneath the prompt while
+                  a Ctrl+R search is active. Hidden otherwise. */}
+              {searchMode && (
+                <div className="absolute top-full left-0 right-0 mt-1 text-[10px] font-mono text-tui-muted flex items-center gap-3">
+                  <span>
+                    {searchMatches.length > 0
+                      ? `${searchMatchIndex + 1}/${searchMatches.length}`
+                      : 'no match'}
+                  </span>
+                  <span>
+                    <span className="text-terminal-bright-green">⌃R</span> next ·{' '}
+                    <span className="text-terminal-bright-green">↵</span> run ·{' '}
+                    <span className="text-terminal-bright-green">tab</span> edit ·{' '}
+                    <span className="text-terminal-bright-green">esc</span> cancel
+                  </span>
+                </div>
+              )}
+
               {/* Autocomplete Dropdown */}
               {showAutocomplete && suggestions.length > 0 && (
                 <div
@@ -530,7 +645,7 @@ function Terminal({ onSwitchToGUI }: TerminalProps) {
           themeName={getSavedTheme().name.toLowerCase()}
           blockCount={lines.filter((l) => l.isCommand).length}
           historyCount={historyLength}
-          mode={paletteOpen ? 'palette' : 'insert'}
+          mode={searchMode ? 'search' : paletteOpen ? 'palette' : 'insert'}
         />
       </div>
 

--- a/client/src/components/tui/Block.tsx
+++ b/client/src/components/tui/Block.tsx
@@ -12,21 +12,22 @@ import {
 /**
  * The canonical chrome primitive for every command's output.
  *
- * Visual grammar is adopted from Textual and Ratatui — a titled border
- * where the title "punches through" the top edge. A thicker left rail
- * marks the output as an addressable block in the Warp sense; it fades
- * on hover to suggest rerun/copy affordances (wired in later phases).
+ * Visual grammar borrows from Textual / Ratatui (titled top border with
+ * the title "punching through") and Warp (left rail as a hover-revealed
+ * affordance, not a permanent fence). Default state: top hairline +
+ * `// title` only, rail-space reserved but transparent. Hover state:
+ * the rail lights up to mark the block as addressable. Avoids the
+ * "every command is fenced" feeling of a permanent rail.
  *
- *   ┌─── // about ────────────────────────── 14:32 ──
- *   │
- *   │   body content
- *   │
- *   └──────────────────────────────────────────────
+ *   ─── // about ────────────────────────── 14:32 ──
  *
- * The title is rendered inline with `font-mono` in accent-bright; the
- * border is accent-dim at 40% opacity; the rail is accent-dim solid.
- * The background is solid `terminal-black` so the title can visually
- * punch through the border line.
+ *       body content
+ *
+ *   (on hover, a 3px accent-bright rail appears on the left)
+ *
+ * Title is `font-mono` in accent-bright; top border is accent-dim at
+ * 40% opacity. Background is solid `terminal-black` so the title
+ * punches through the top hairline cleanly.
  */
 
 interface BlockProps {
@@ -80,21 +81,22 @@ export function Block({
       id={id}
       role="region"
       aria-labelledby={titleId}
-      // Chrome: left rail (strong) + top rule (subtle) only. The full
-      // 4-sided border we had before gave each block a "right-edge
-      // border" that read as visual noise — the left rail already
-      // marks the block, and title+top-rule close the top. Bubble
-      // Tea / Ratatui panels skip the right/bottom for the same
-      // reason. Bottom spacing comes from my-4; blocks naturally
-      // separate without a closing rule.
-      className={`tui-block group relative my-4 border-t border-tui-accent-dim/40 border-l-[3px] border-l-terminal-bright-green bg-terminal-black ${widthCls} ${className}`}
+      // Chrome: top hairline + title only by default. The left rail
+      // is reserved (3px transparent) but invisible until hover —
+      // Warp idiom. This stops every block reading as a fenced cell;
+      // the title + top rule + my-4 spacing carry the delimitation,
+      // and the rail becomes a hover-revealed "this is addressable"
+      // affordance instead of a permanent fence.
+      className={`tui-block group relative my-4 border-t border-tui-accent-dim/40 border-l-[3px] border-l-transparent hover:border-l-terminal-bright-green transition-colors duration-200 bg-terminal-black ${widthCls} ${className}`}
     >
       {/* Title row — positioned to straddle the top border so the text
-          overlays the border line. Header extends from the left rail
-          to the right edge so the title's black background fully
-          clips the top border (no stray "dash" visible between the
-          rail and the title start). */}
-      <header className="pointer-events-none absolute -top-2.5 left-[3px] right-0 flex items-center justify-between font-mono text-xs sm:text-[13px]">
+          overlays the border line. Header extends from x=0 to right
+          edge so the title's black background also clips the top
+          border in the 3px rail-space (otherwise a stray `-` tick
+          shows through where border-left is transparent). On hover
+          the rail still appears below the title's height, so the
+          "title on rail" reading is preserved. */}
+      <header className="pointer-events-none absolute -top-2.5 -left-[3px] right-0 flex items-center justify-between font-mono text-xs sm:text-[13px]">
         <div className="pointer-events-auto flex items-center gap-2">
           <span
             id={titleId}

--- a/client/src/components/tui/Block.tsx
+++ b/client/src/components/tui/Block.tsx
@@ -80,7 +80,14 @@ export function Block({
       id={id}
       role="region"
       aria-labelledby={titleId}
-      className={`tui-block group relative my-4 border border-tui-accent-dim/40 border-l-[3px] border-l-terminal-bright-green bg-terminal-black terminal-glow ${widthCls} ${className}`}
+      // Chrome: left rail (strong) + top rule (subtle) only. The full
+      // 4-sided border we had before gave each block a "right-edge
+      // border" that read as visual noise — the left rail already
+      // marks the block, and title+top-rule close the top. Bubble
+      // Tea / Ratatui panels skip the right/bottom for the same
+      // reason. Bottom spacing comes from my-4; blocks naturally
+      // separate without a closing rule.
+      className={`tui-block group relative my-4 border-t border-tui-accent-dim/40 border-l-[3px] border-l-terminal-bright-green bg-terminal-black ${widthCls} ${className}`}
     >
       {/* Title row — positioned to straddle the top border so the text
           overlays the border line. Header extends from the left rail

--- a/client/src/components/tui/Block.tsx
+++ b/client/src/components/tui/Block.tsx
@@ -83,13 +83,15 @@ export function Block({
       className={`tui-block group relative my-4 border border-tui-accent-dim/40 border-l-[3px] border-l-terminal-bright-green bg-terminal-black terminal-glow ${widthCls} ${className}`}
     >
       {/* Title row — positioned to straddle the top border so the text
-          overlays the border line. The black bg on the title clips the
-          border underneath, producing the "punched through" look. */}
-      <header className="pointer-events-none absolute -top-2.5 left-3 right-3 flex items-center justify-between font-mono text-xs sm:text-[13px]">
+          overlays the border line. Header extends from the left rail
+          to the right edge so the title's black background fully
+          clips the top border (no stray "dash" visible between the
+          rail and the title start). */}
+      <header className="pointer-events-none absolute -top-2.5 left-[3px] right-0 flex items-center justify-between font-mono text-xs sm:text-[13px]">
         <div className="pointer-events-auto flex items-center gap-2">
           <span
             id={titleId}
-            className="bg-terminal-black px-2 text-terminal-bright-green tracking-wide"
+            className="bg-terminal-black pl-2 pr-3 text-terminal-bright-green tracking-wide"
           >
             {title}
           </span>
@@ -100,7 +102,7 @@ export function Block({
           )}
         </div>
         {timestamp && (
-          <time className="pointer-events-auto bg-terminal-black px-2 text-tui-muted text-[10px] sm:text-[11px] tabular-nums">
+          <time className="pointer-events-auto bg-terminal-black pl-2 pr-3 text-tui-muted text-[10px] sm:text-[11px] tabular-nums">
             {timestamp}
           </time>
         )}

--- a/client/src/components/tui/Block.tsx
+++ b/client/src/components/tui/Block.tsx
@@ -1,0 +1,182 @@
+import {
+  createContext,
+  useCallback,
+  useContext,
+  useEffect,
+  useMemo,
+  useRef,
+  useState,
+  type ReactNode,
+} from 'react';
+
+/**
+ * The canonical chrome primitive for every command's output.
+ *
+ * Visual grammar is adopted from Textual and Ratatui — a titled border
+ * where the title "punches through" the top edge. A thicker left rail
+ * marks the output as an addressable block in the Warp sense; it fades
+ * on hover to suggest rerun/copy affordances (wired in later phases).
+ *
+ *   ┌─── // about ────────────────────────── 14:32 ──
+ *   │
+ *   │   body content
+ *   │
+ *   └──────────────────────────────────────────────
+ *
+ * The title is rendered inline with `font-mono` in accent-bright; the
+ * border is accent-dim at 40% opacity; the rail is accent-dim solid.
+ * The background is solid `terminal-black` so the title can visually
+ * punch through the border line.
+ */
+
+interface BlockProps {
+  /** Title string — callers pass `// about` etc. This primitive does
+      not prepend `// ` automatically so callers retain control. */
+  title: string;
+  /** Stable id used for Warp-style block addressing and a11y. */
+  id?: string;
+  /** Optional right-aligned timestamp string (e.g. "14:32:18"). */
+  timestamp?: string;
+  /** Additional controls rendered to the right of the title, left of
+      the timestamp. Typically `[−]` / `[↻]` / `[⧉]` chips. */
+  controls?: ReactNode;
+  /** Body contents. */
+  children: ReactNode;
+  /** Override the default vertical rhythm inside the body. */
+  bodyClassName?: string;
+  /** Extra classes on the outer shell. */
+  className?: string;
+  /** Tight-body variant: no inner padding, for ASCII art / preformatted
+      content that should hug the border. */
+  dense?: boolean;
+  /** Optional hero variant — wider max-width for welcome / replicate
+      which hold more content than a typical command output. */
+  wide?: boolean;
+}
+
+export function Block({
+  title,
+  id,
+  timestamp,
+  controls,
+  children,
+  bodyClassName,
+  className = '',
+  dense = false,
+  wide = false,
+}: BlockProps) {
+  const widthCls = wide ? 'max-w-5xl' : 'max-w-4xl';
+  const bodyCls =
+    bodyClassName ??
+    (dense
+      ? 'text-sm sm:text-base'
+      : 'p-3 pt-4 sm:p-4 sm:pt-5 space-y-3 sm:space-y-4 text-sm sm:text-base');
+
+  // Title id for aria-labelledby. Stable across renders.
+  const titleId = id ? `${id}-title` : undefined;
+
+  return (
+    <section
+      id={id}
+      role="region"
+      aria-labelledby={titleId}
+      className={`tui-block group relative my-4 border border-tui-accent-dim/40 border-l-[3px] border-l-terminal-bright-green bg-terminal-black terminal-glow ${widthCls} ${className}`}
+    >
+      {/* Title row — positioned to straddle the top border so the text
+          overlays the border line. The black bg on the title clips the
+          border underneath, producing the "punched through" look. */}
+      <header className="pointer-events-none absolute -top-2.5 left-3 right-3 flex items-center justify-between font-mono text-xs sm:text-[13px]">
+        <div className="pointer-events-auto flex items-center gap-2">
+          <span
+            id={titleId}
+            className="bg-terminal-black px-2 text-terminal-bright-green tracking-wide"
+          >
+            {title}
+          </span>
+          {controls && (
+            <span className="pointer-events-auto bg-terminal-black px-1 text-tui-muted">
+              {controls}
+            </span>
+          )}
+        </div>
+        {timestamp && (
+          <time className="pointer-events-auto bg-terminal-black px-2 text-tui-muted text-[10px] sm:text-[11px] tabular-nums">
+            {timestamp}
+          </time>
+        )}
+      </header>
+
+      <BlockLinkProvider>
+        <div className={bodyCls}>{children}</div>
+      </BlockLinkProvider>
+    </section>
+  );
+}
+
+// ── Link registry (consumed in Phase 7 for `o N` / `g N` activation) ──
+
+export interface BlockLinkInfo {
+  n: number;
+  href: string;
+  label: string;
+}
+
+interface BlockLinkRegistry {
+  register: (href: string, label: string) => number;
+  getLink: (n: number) => BlockLinkInfo | undefined;
+  all: () => BlockLinkInfo[];
+}
+
+const BlockLinkContext = createContext<BlockLinkRegistry | null>(null);
+
+function BlockLinkProvider({ children }: { children: ReactNode }) {
+  const counter = useRef(0);
+  const mapRef = useRef<Map<number, BlockLinkInfo>>(new Map());
+  // Reset each render — NumberedLink will re-register during the render
+  // pass, producing a stable 1-based index by document order.
+  counter.current = 0;
+  mapRef.current.clear();
+
+  const register = useCallback((href: string, label: string) => {
+    const n = ++counter.current;
+    mapRef.current.set(n, { n, href, label });
+    return n;
+  }, []);
+  const getLink = useCallback((n: number) => mapRef.current.get(n), []);
+  const all = useCallback(() => Array.from(mapRef.current.values()), []);
+
+  const value = useMemo<BlockLinkRegistry>(
+    () => ({ register, getLink, all }),
+    [register, getLink, all],
+  );
+  return <BlockLinkContext.Provider value={value}>{children}</BlockLinkContext.Provider>;
+}
+
+export function useBlockLinks(): BlockLinkRegistry | null {
+  return useContext(BlockLinkContext);
+}
+
+// ── Convenience hook: block header timestamp in a stable "HH:MM" form ──
+
+/** Returns the current HH:MM:SS string, updated once a second. Useful
+ *  as the `timestamp` prop on long-lived blocks. Most command outputs
+ *  will pass a fixed string captured at execution time. */
+export function useLiveClock(): string {
+  const [now, setNow] = useState(() => formatClock(new Date()));
+  useEffect(() => {
+    const t = setInterval(() => setNow(formatClock(new Date())), 1000);
+    return () => clearInterval(t);
+  }, []);
+  return now;
+}
+
+function formatClock(d: Date): string {
+  const pad = (n: number) => n.toString().padStart(2, '0');
+  return `${pad(d.getHours())}:${pad(d.getMinutes())}:${pad(d.getSeconds())}`;
+}
+
+/** One-shot clock — returns a "HH:MM:SS" string for now. Use this for
+ *  block timestamps so they freeze at block creation. */
+export function nowClock(): string {
+  return formatClock(new Date());
+}

--- a/client/src/components/tui/BootSequence.tsx
+++ b/client/src/components/tui/BootSequence.tsx
@@ -1,0 +1,95 @@
+import { useEffect, useState } from 'react';
+import { motion, useReducedMotion } from 'framer-motion';
+
+interface BootSequenceProps {
+  /** Called once all lines have finished revealing (or when the user
+   *  skips via click / keypress). */
+  onComplete: () => void;
+  /** Short git sha or build id to show in the final line. Optional. */
+  buildId?: string;
+  /** Display theme name (lowercase). */
+  themeName?: string;
+}
+
+/**
+ * Old-school CRT boot messages. Three lines phosphor-flicker in over
+ * ~800ms, then hand off to the welcome block. Any keypress or pointer
+ * event skips to completion. Respects `prefers-reduced-motion`:
+ * reduced users get the three lines rendered instantly, no flicker.
+ */
+export function BootSequence({
+  onComplete,
+  buildId = 'dev',
+  themeName = 'matrix',
+}: BootSequenceProps) {
+  const prefersReducedMotion = useReducedMotion();
+  const [step, setStep] = useState(0);
+  const [done, setDone] = useState(false);
+
+  const tz = Intl.DateTimeFormat().resolvedOptions().timeZone.split('/').pop() ?? 'utc';
+
+  const lines = [
+    'booting tui… ok',
+    'loading portfolio data… ok',
+    `mounted session ${buildId} · theme: ${themeName} · tz: ${tz.toLowerCase()}`,
+  ];
+
+  // Advance one line at a time on a fixed cadence.
+  useEffect(() => {
+    if (done) return;
+    const delay = prefersReducedMotion ? 0 : 260;
+    const t = setTimeout(() => {
+      if (step < lines.length) {
+        setStep((s) => s + 1);
+      } else {
+        // Short hold after the last line so users can read it.
+        setDone(true);
+        setTimeout(onComplete, prefersReducedMotion ? 0 : 300);
+      }
+    }, delay);
+    return () => clearTimeout(t);
+  }, [step, done, prefersReducedMotion, lines.length, onComplete]);
+
+  // Skip on any pointer / key event.
+  useEffect(() => {
+    const skip = () => {
+      if (done) return;
+      setDone(true);
+      onComplete();
+    };
+    window.addEventListener('keydown', skip, { once: true });
+    window.addEventListener('pointerdown', skip, { once: true });
+    return () => {
+      window.removeEventListener('keydown', skip);
+      window.removeEventListener('pointerdown', skip);
+    };
+  }, [done, onComplete]);
+
+  return (
+    <div className="font-mono text-sm sm:text-base text-terminal-green space-y-1 mb-4">
+      {lines.slice(0, step).map((line, i) => (
+        <motion.div
+          key={i}
+          initial={prefersReducedMotion ? false : { opacity: 0, filter: 'blur(4px)' }}
+          animate={{ opacity: 1, filter: 'blur(0px)' }}
+          transition={{ duration: 0.18, ease: 'easeOut' }}
+          className="flex items-baseline gap-2"
+        >
+          <span className="text-terminal-bright-green tabular-nums text-xs">
+            [{(i + 1).toString().padStart(2, '0')}]
+          </span>
+          <span>{line}</span>
+          {/* Inline check glyph for completed lines */}
+          {i < step - 1 && (
+            <span className="text-terminal-bright-green/50 text-[10px]">✓</span>
+          )}
+        </motion.div>
+      ))}
+      {!done && step < lines.length && (
+        <div className="text-tui-muted text-xs italic">
+          press any key to skip…
+        </div>
+      )}
+    </div>
+  );
+}

--- a/client/src/components/tui/BrailleSparkline.tsx
+++ b/client/src/components/tui/BrailleSparkline.tsx
@@ -1,0 +1,90 @@
+interface BrailleSparklineProps {
+  /** Time-series data. Any numeric scale. Zero-length renders empty. */
+  data: number[];
+  /** Width in characters. Data is bucketed to fit. Default 24. */
+  width?: number;
+  /** Optional inline className for the glyph sequence. */
+  className?: string;
+  /** Optional label shown to the right of the sparkline, e.g. "1.2k". */
+  trailing?: string;
+}
+
+/**
+ * Block-character sparkline — `▁▂▃▄▅▆▇█` from Unicode Block Elements.
+ * This is the btop / bpytop idiom: inline vertical bars that scan as
+ * a mini chart without needing a canvas. One character per bucket,
+ * so it composes naturally inside mono text.
+ *
+ * The name "Braille" is historical — we briefly considered the 2-
+ * dimensional braille-dot encoding but block chars render more
+ * legibly at terminal body font sizes.
+ */
+
+const BARS = ['▁', '▂', '▃', '▄', '▅', '▆', '▇', '█'] as const;
+
+export function BrailleSparkline({
+  data,
+  width = 24,
+  className = '',
+  trailing,
+}: BrailleSparklineProps) {
+  if (data.length === 0) {
+    return (
+      <span className={`font-mono text-tui-muted ${className}`}>
+        {' '.repeat(width)}
+        {trailing && <span className="ml-2">{trailing}</span>}
+      </span>
+    );
+  }
+
+  const bucketed = bucket(data, width);
+  const max = Math.max(...bucketed);
+  const min = Math.min(...bucketed);
+  const range = max - min || 1;
+
+  const glyphs = bucketed
+    .map((v) => {
+      const norm = (v - min) / range;
+      const idx = Math.min(BARS.length - 1, Math.floor(norm * BARS.length));
+      return BARS[idx];
+    })
+    .join('');
+
+  return (
+    <span className={`inline-flex items-baseline gap-2 font-mono ${className}`}>
+      <span className="text-terminal-bright-green tracking-tight leading-none">
+        {glyphs}
+      </span>
+      {trailing && (
+        <span className="text-tui-muted text-[10px] tabular-nums">{trailing}</span>
+      )}
+    </span>
+  );
+}
+
+/** Bucket a potentially-long series into exactly `width` buckets by
+ *  linear interpolation. Each bucket is the average of its range. */
+function bucket(data: number[], width: number): number[] {
+  if (data.length <= width) return data;
+  const out = new Array(width).fill(0);
+  const ratio = data.length / width;
+  for (let i = 0; i < width; i++) {
+    const start = Math.floor(i * ratio);
+    const end = Math.floor((i + 1) * ratio);
+    let sum = 0;
+    let count = 0;
+    for (let j = start; j < end; j++) {
+      sum += data[j];
+      count++;
+    }
+    out[i] = count > 0 ? sum / count : data[start] ?? 0;
+  }
+  return out;
+}
+
+/** Format a number compactly: 1234 → "1.2k", 1_500_000 → "1.5m". */
+export function formatCompact(n: number): string {
+  if (n >= 1_000_000) return `${(n / 1_000_000).toFixed(1)}m`;
+  if (n >= 1_000) return `${(n / 1_000).toFixed(1)}k`;
+  return String(n);
+}

--- a/client/src/components/tui/Collapsible.tsx
+++ b/client/src/components/tui/Collapsible.tsx
@@ -45,12 +45,12 @@ export function CollapsibleGroup({
         <button
           type="button"
           onClick={toggleAll}
-          className="text-xs px-2 py-1 border border-terminal-green/50 rounded hover:bg-terminal-green/10 transition-colors text-terminal-yellow focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-terminal-bright-green"
+          className="text-[10px] px-1.5 py-0.5 border border-tui-accent-dim/50 hover:bg-terminal-bright-green/10 transition-colors text-tui-accent-dim focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-terminal-bright-green font-mono"
         >
           <span aria-hidden="true" className="mr-1">
             {allOpen ? '⌃' : '⌄'}
           </span>
-          {allOpen ? 'Collapse All' : 'Expand All'}
+          {allOpen ? 'collapse all' : 'expand all'}
         </button>
       }
       bodyClassName={bodyClassName}
@@ -82,12 +82,12 @@ interface CollapsibleItemProps {
 
 function CollapsibleItem({ header, children, isOpen, onToggle }: CollapsibleItemProps) {
   return (
-    <div className="border border-terminal-green/20 rounded">
+    <div className="border border-tui-accent-dim/30 border-l-2 border-l-tui-accent-dim/60">
       <button
         type="button"
         onClick={onToggle}
         aria-expanded={isOpen}
-        className="w-full cursor-pointer hover:bg-terminal-green/10 transition-colors p-3 text-left focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-terminal-bright-green rounded"
+        className="w-full cursor-pointer hover:bg-terminal-bright-green/5 transition-colors p-3 text-left focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-terminal-bright-green"
       >
         <div className="flex items-center justify-between">
           <div className="flex-1">{header}</div>
@@ -102,7 +102,7 @@ function CollapsibleItem({ header, children, isOpen, onToggle }: CollapsibleItem
         </div>
       </button>
       {isOpen && (
-        <div className="border-t border-terminal-green/20 p-3 pt-2">{children}</div>
+        <div className="border-t border-tui-accent-dim/30 p-3 pt-2">{children}</div>
       )}
     </div>
   );

--- a/client/src/components/tui/CommandPalette.tsx
+++ b/client/src/components/tui/CommandPalette.tsx
@@ -1,0 +1,349 @@
+import {
+  useCallback,
+  useEffect,
+  useMemo,
+  useRef,
+  useState,
+} from 'react';
+import type { CommandMetadata } from '../../hooks/useTerminal';
+import { Kbd } from './Kbd';
+
+interface CommandPaletteProps {
+  open: boolean;
+  onClose: () => void;
+  /** All commands available given the current portfolio data. */
+  commands: CommandMetadata[];
+  /** Newest-first history (for the Recents section). */
+  recentCommands: string[];
+  /** Execute a command string (as if typed). */
+  onExecute: (cmd: string) => void;
+}
+
+/**
+ * Warp / VS Code-style fuzzy command palette. Triggered by Ctrl+K or
+ * Cmd+K anywhere in the TUI; typing filters the command list in real
+ * time. The right pane shows a short preview (description + aliases
+ * + argsHint) for the highlighted entry.
+ *
+ * When input is empty, the list shows "recents" (the 3 most-recent
+ * commands) pinned at the top, then the full command list.
+ */
+export function CommandPalette({
+  open,
+  onClose,
+  commands,
+  recentCommands,
+  onExecute,
+}: CommandPaletteProps) {
+  const [query, setQuery] = useState('');
+  const [cursor, setCursor] = useState(0);
+  const inputRef = useRef<HTMLInputElement>(null);
+  const listRef = useRef<HTMLDivElement>(null);
+
+  // Reset state on open; focus input so typing is instant.
+  useEffect(() => {
+    if (!open) return;
+    setQuery('');
+    setCursor(0);
+    // One paint to ensure the dialog is mounted before focus.
+    const id = requestAnimationFrame(() => inputRef.current?.focus());
+    return () => cancelAnimationFrame(id);
+  }, [open]);
+
+  // ESC anywhere closes.
+  useEffect(() => {
+    if (!open) return;
+    const onKey = (e: KeyboardEvent) => {
+      if (e.key === 'Escape') {
+        e.preventDefault();
+        onClose();
+      }
+    };
+    window.addEventListener('keydown', onKey);
+    return () => window.removeEventListener('keydown', onKey);
+  }, [open, onClose]);
+
+  // Lock body scroll while open.
+  useEffect(() => {
+    if (!open) return;
+    const prev = document.body.style.overflow;
+    document.body.style.overflow = 'hidden';
+    return () => {
+      document.body.style.overflow = prev;
+    };
+  }, [open]);
+
+  // Build the ranked, filtered list.
+  const entries = useMemo(
+    () => buildEntries(commands, recentCommands, query),
+    [commands, recentCommands, query],
+  );
+  const active = entries[cursor];
+
+  // Clamp cursor when entry count changes.
+  useEffect(() => {
+    if (cursor >= entries.length) setCursor(Math.max(0, entries.length - 1));
+  }, [entries.length, cursor]);
+
+  // Scroll the active row into view on cursor move.
+  useEffect(() => {
+    if (!listRef.current) return;
+    const el = listRef.current.querySelector<HTMLElement>(
+      `[data-idx="${cursor}"]`,
+    );
+    el?.scrollIntoView({ block: 'nearest' });
+  }, [cursor]);
+
+  const runActive = useCallback(() => {
+    if (!active) return;
+    const cmdStr = active.argsHint
+      ? active.name // leave args for the user to fill after selection
+      : active.name;
+    onClose();
+    // Defer one frame so the overlay unmounts before the command fires.
+    requestAnimationFrame(() => onExecute(cmdStr));
+  }, [active, onClose, onExecute]);
+
+  if (!open) return null;
+
+  return (
+    <div
+      role="dialog"
+      aria-modal="true"
+      aria-label="command palette"
+      onClick={(e) => {
+        if (e.target === e.currentTarget) onClose();
+      }}
+      className="fixed inset-0 z-50 bg-black/70 flex items-start justify-center pt-[18vh] px-4"
+    >
+      <div className="relative bg-terminal-black border border-tui-accent-dim/50 border-l-[3px] border-l-terminal-bright-green w-full max-w-2xl terminal-glow flex flex-col max-h-[70vh]">
+        {/* Punched-through title */}
+        <div className="pointer-events-none absolute -top-2.5 left-3 right-3 flex items-center justify-between font-mono text-xs">
+          <span className="bg-terminal-black px-2 text-terminal-bright-green pointer-events-auto">
+            // palette
+          </span>
+          <span className="bg-terminal-black px-2 text-tui-muted pointer-events-auto">
+            <Kbd>esc</Kbd> to close
+          </span>
+        </div>
+
+        {/* Search input */}
+        <div className="flex items-center border-b border-tui-accent-dim/30 px-3 pt-4 pb-2 font-mono">
+          <span className="text-terminal-bright-green text-xs mr-2">❯</span>
+          <input
+            ref={inputRef}
+            type="text"
+            value={query}
+            onChange={(e) => {
+              setQuery(e.target.value);
+              setCursor(0);
+            }}
+            onKeyDown={(e) => {
+              if (e.key === 'ArrowDown') {
+                e.preventDefault();
+                setCursor((c) => (c + 1) % Math.max(1, entries.length));
+              } else if (e.key === 'ArrowUp') {
+                e.preventDefault();
+                setCursor((c) => (c - 1 + entries.length) % Math.max(1, entries.length));
+              } else if (e.key === 'Enter') {
+                e.preventDefault();
+                runActive();
+              } else if (e.key === 'Tab') {
+                e.preventDefault();
+                if (active) setQuery(active.name);
+              }
+            }}
+            placeholder="type to filter commands…"
+            className="flex-1 bg-transparent text-terminal-green outline-none text-sm placeholder:text-tui-muted"
+            aria-label="filter commands"
+            spellCheck="false"
+            autoComplete="off"
+          />
+          {entries.length > 0 && (
+            <span className="text-tui-muted text-[10px] tabular-nums ml-2">
+              {cursor + 1}/{entries.length}
+            </span>
+          )}
+        </div>
+
+        {/* Results + preview */}
+        <div className="flex-1 grid grid-cols-5 overflow-hidden">
+          <div
+            ref={listRef}
+            role="listbox"
+            aria-label="commands"
+            className="col-span-3 overflow-y-auto scrollbar-terminal border-r border-tui-accent-dim/30 py-1"
+          >
+            {entries.length === 0 && (
+              <div className="p-4 text-tui-muted text-xs font-mono">
+                no commands match "{query}"
+              </div>
+            )}
+            {entries.map((entry, i) => (
+              <button
+                key={entry.key}
+                data-idx={i}
+                role="option"
+                aria-selected={i === cursor}
+                onMouseEnter={() => setCursor(i)}
+                onClick={() => {
+                  setCursor(i);
+                  runActive();
+                }}
+                className={`w-full text-left px-3 py-1 flex items-center justify-between gap-3 font-mono text-xs sm:text-sm border-l-2 ${
+                  i === cursor
+                    ? 'border-terminal-bright-green bg-terminal-bright-green/10 text-terminal-bright-green'
+                    : 'border-transparent text-terminal-green hover:bg-terminal-bright-green/5'
+                }`}
+              >
+                <span className="flex items-center gap-2 min-w-0">
+                  {entry.recent && (
+                    <span className="text-tui-muted text-[9px] shrink-0">
+                      recent
+                    </span>
+                  )}
+                  <span className="truncate">{entry.name}</span>
+                  {entry.argsHint && (
+                    <span className="text-tui-accent-dim text-[10px] shrink-0">
+                      {entry.argsHint}
+                    </span>
+                  )}
+                </span>
+                <span className="text-tui-muted text-[10px] shrink-0 hidden sm:inline">
+                  {entry.category}
+                </span>
+              </button>
+            ))}
+          </div>
+          <div className="col-span-2 p-3 overflow-y-auto scrollbar-terminal font-mono text-xs">
+            {active ? (
+              <div className="space-y-2">
+                <div className="text-tui-accent-dim">// preview</div>
+                <div className="text-terminal-bright-green text-sm">
+                  {active.name}
+                  {active.argsHint && (
+                    <span className="text-tui-accent-dim ml-1 text-xs">
+                      {active.argsHint}
+                    </span>
+                  )}
+                </div>
+                <div className="text-white/80 leading-relaxed">
+                  {active.description}
+                </div>
+                {active.aliases && active.aliases.length > 0 && (
+                  <div className="text-tui-muted text-[10px]">
+                    aliases: {active.aliases.join(', ')}
+                  </div>
+                )}
+                <div className="pt-2 mt-2 border-t border-tui-accent-dim/30 text-[10px] text-tui-muted space-y-0.5">
+                  <div>
+                    <Kbd>↵</Kbd> run
+                  </div>
+                  <div>
+                    <Kbd>tab</Kbd> complete into input
+                  </div>
+                  <div>
+                    <Kbd>↑↓</Kbd> navigate
+                  </div>
+                </div>
+              </div>
+            ) : (
+              <div className="text-tui-muted">no selection</div>
+            )}
+          </div>
+        </div>
+      </div>
+    </div>
+  );
+}
+
+// ── Matcher ──
+
+interface PaletteEntry extends CommandMetadata {
+  key: string;
+  recent: boolean;
+  /** Lower = better; used for sort. */
+  score: number;
+}
+
+function buildEntries(
+  commands: CommandMetadata[],
+  recents: string[],
+  query: string,
+): PaletteEntry[] {
+  const q = query.trim().toLowerCase();
+
+  // Recents — dedup and preserve newest-first; cap at 3.
+  const seen = new Set<string>();
+  const recentNames: string[] = [];
+  for (const r of recents) {
+    const base = r.trim().split(/\s+/)[0]?.toLowerCase();
+    if (!base || seen.has(base)) continue;
+    if (commands.some((c) => c.name === base || c.aliases?.includes(base))) {
+      recentNames.push(base);
+      seen.add(base);
+      if (recentNames.length >= 3) break;
+    }
+  }
+
+  // Empty query — recents pinned, then full list alphabetised.
+  if (!q) {
+    const out: PaletteEntry[] = [];
+    for (const name of recentNames) {
+      const c = commands.find((x) => x.name === name || x.aliases?.includes(name));
+      if (c) out.push({ ...c, key: `recent:${c.name}`, recent: true, score: 0 });
+    }
+    const already = new Set(out.map((e) => e.name));
+    for (const c of commands) {
+      if (already.has(c.name)) continue;
+      out.push({ ...c, key: c.name, recent: false, score: 0 });
+    }
+    return out;
+  }
+
+  // Filtered — score each command.
+  const scored: PaletteEntry[] = [];
+  for (const c of commands) {
+    const score = fuzzyScore(q, c);
+    if (score === null) continue;
+    scored.push({
+      ...c,
+      key: c.name,
+      recent: recentNames.includes(c.name),
+      score,
+    });
+  }
+  scored.sort((a, b) => a.score - b.score || a.name.localeCompare(b.name));
+  return scored;
+}
+
+/** Lower = better match. `null` = no match. */
+function fuzzyScore(q: string, cmd: CommandMetadata): number | null {
+  const candidates = [cmd.name, ...(cmd.aliases ?? []), cmd.description.toLowerCase()];
+  let best: number | null = null;
+  for (const cand of candidates) {
+    const s = scoreAgainst(q, cand.toLowerCase());
+    if (s !== null && (best === null || s < best)) best = s;
+  }
+  return best;
+}
+
+function scoreAgainst(q: string, target: string): number | null {
+  if (!target.length) return null;
+  // Exact match — best.
+  if (target === q) return 0;
+  // Prefix — very good.
+  if (target.startsWith(q)) return 1 + target.length - q.length;
+  // Contains — good.
+  const idx = target.indexOf(q);
+  if (idx !== -1) return 10 + idx;
+  // Subsequence — e.g. "abt" matches "about".
+  let ti = 0;
+  for (let qi = 0; qi < q.length; qi++) {
+    const ch = q[qi];
+    const found = target.indexOf(ch, ti);
+    if (found === -1) return null;
+    ti = found + 1;
+  }
+  return 50 + target.length - q.length;
+}

--- a/client/src/components/tui/CommandPalette.tsx
+++ b/client/src/components/tui/CommandPalette.tsx
@@ -114,6 +114,8 @@ export function CommandPalette({
       onClick={(e) => {
         if (e.target === e.currentTarget) onClose();
       }}
+      // Keep the keyboard focus trap shallow: only Esc + the palette's
+      // own keydowns need to matter, and the input auto-focuses on mount.
       className="fixed inset-0 z-50 bg-black/70 flex items-start justify-center pt-[18vh] px-4"
     >
       <div className="relative bg-terminal-black border border-tui-accent-dim/50 border-l-[3px] border-l-terminal-bright-green w-full max-w-2xl terminal-glow flex flex-col max-h-[70vh]">

--- a/client/src/components/tui/ExploreMore.tsx
+++ b/client/src/components/tui/ExploreMore.tsx
@@ -12,19 +12,19 @@ interface ExploreMoreProps {
 }
 
 /**
- * The "💡 EXPLORE MORE" footer block that lives at the bottom of most
+ * The "// explore more" footer block that lives at the bottom of most
  * command outputs. Each item is a bullet with an internal CmdLink and
- * a short description. Matches the visual conventions used site-wide.
+ * a short description. Matches the GUI's `// comment` label idiom.
  */
 export function ExploreMore({ items }: ExploreMoreProps) {
   return (
-    <div className="border-t border-terminal-green/30 pt-3">
-      <div className="text-terminal-yellow font-bold mb-2">💡 EXPLORE MORE</div>
-      <div className="space-y-1 ml-2 text-xs">
+    <div className="border-t border-tui-accent-dim/30 pt-3">
+      <div className="text-tui-accent-dim text-xs mb-2">// explore more</div>
+      <div className="space-y-0.5 ml-1 text-xs">
         {items.map((it) => (
-          <div key={it.cmd}>
-            <span className="text-white">• </span>
-            Try <CmdLink cmd={it.cmd}>{it.label ?? it.cmd}</CmdLink>
+          <div key={it.cmd} className="text-white/80">
+            <span className="text-tui-accent-dim">· </span>
+            try <CmdLink cmd={it.cmd}>{it.label ?? it.cmd}</CmdLink>
             {it.suffix ? ' ' : ''}
             {it.suffix}
           </div>

--- a/client/src/components/tui/IdleMatrixRain.tsx
+++ b/client/src/components/tui/IdleMatrixRain.tsx
@@ -61,7 +61,14 @@ export function IdleMatrixRain({ active }: IdleMatrixRainProps) {
     const fontSize = 14;
     const rect = canvas.getBoundingClientRect();
     const columns = Math.floor(rect.width / fontSize);
-    const drops: number[] = Array(columns).fill(0).map(() => Math.random() * -50);
+    // Drops start uniformly distributed across the viewport height
+    // (expressed in rows) so the rain looks "full" the instant the
+    // user triggers it — previously we used Math.random() * -50 which
+    // meant ~12 seconds before columns were visible.
+    const rowsOnScreen = Math.ceil(rect.height / fontSize);
+    const drops: number[] = Array(columns)
+      .fill(0)
+      .map(() => Math.random() * rowsOnScreen);
     // Per-column optional decoded-word state.
     const words: Array<{ text: string; pos: number } | null> =
       Array(columns).fill(null);
@@ -127,7 +134,12 @@ export function IdleMatrixRain({ active }: IdleMatrixRainProps) {
     <canvas
       ref={canvasRef}
       aria-hidden="true"
-      className="pointer-events-none absolute inset-0 z-[5] opacity-70"
+      // Absolute inset-0 against the Terminal's outer shell (which is
+      // `position: relative; h-screen`), so the canvas covers the whole
+      // terminal viewport regardless of how far the user has scrolled
+      // the output pane. z-20 keeps it above scanlines + scrollback,
+      // below the command input and status bar.
+      className="pointer-events-none absolute inset-0 z-20 opacity-80"
     />
   );
 }

--- a/client/src/components/tui/IdleMatrixRain.tsx
+++ b/client/src/components/tui/IdleMatrixRain.tsx
@@ -1,145 +1,230 @@
 import { useEffect, useRef } from 'react';
 import { useReducedMotion } from 'framer-motion';
+import { getAccentRgb } from '../../config/gui-theme.config';
 
 interface IdleMatrixRainProps {
-  /** When true, the overlay is mounted and the rain animates. */
+  /** When true, the overlay fades in and animates. When false, fades out. */
   active: boolean;
 }
 
-const GLYPHS =
-  'アイウエオカキクケコサシスセソタチツテトナニヌネノハヒフヘホマミムメモヤユヨラリルレロワヲン0123456789';
+const KATAKANA = 'アイウエオカキクケコサシスセソタチツテトナニヌネノハヒフヘホマミムメモヤユヨラリルレロワヲン';
+const DIGITS = '0123456789';
+const CHARS = (KATAKANA + DIGITS + '@#$%&').split('');
+const FADE_IN_MS = 600;
+const FADE_OUT_MS = 400;
+const COL_WIDTH = 22;
+const RARE_GLYPHS = ['♥', '★', '✦', '☕', '☽', '☾', '♠', '♦', '⚡', '☄', '✧', '♪'];
+const RARE_GLYPH_CHANCE = 0.0008;
+
 const HIDDEN_MESSAGES = [
-  'there is no spoon',
   'wake up',
+  'hi curious',
+  'there is no spoon',
+  'follow the rabbit',
   'stay curious',
-  'follow the white rabbit',
   'decode me',
+  'not random',
+  'i see you',
+  'have some coffee',
+  'keep watching',
+  'dont panic',
+  'breathe deep',
 ];
+// Per-frame chance, applied independently to each column. Tuned so a
+// new message starts roughly every ~3-4 seconds across all columns
+// (varies with column count) — frequent enough to feel alive, sparse
+// enough that each message has visual breathing room.
+const MESSAGE_CHANCE_PER_FRAME = 0.00007;
+// Lifetime is BASE + chars * MS_PER_CHAR + random jitter so longer
+// messages get more time to read. "wake up" (7) ≈ 3.4-4.9s,
+// "have some coffee" (16) ≈ 6.3-7.8s, "follow the rabbit" (17) ≈ 6.6-8.1s.
+const MESSAGE_BASE_MS = 1800;
+const MESSAGE_MS_PER_CHAR = 280;
+const MESSAGE_JITTER_MS = 1500;
+
+function randomChar() {
+  if (Math.random() < RARE_GLYPH_CHANCE) {
+    return RARE_GLYPHS[Math.floor(Math.random() * RARE_GLYPHS.length)];
+  }
+  return CHARS[Math.floor(Math.random() * CHARS.length)];
+}
 
 /**
- * Matrix-style falling-glyph overlay scoped to the TUI output pane.
- * Mirrors the GUI's `MatrixRain.tsx` as a lighter-weight terminal
- * screensaver. Positioned absolutely over the terminal content,
- * pointer-events: none so it doesn't steal clicks.
+ * Matrix-style falling-glyph overlay for the TUI. Mirrors the GUI's
+ * MatrixRain visual grammar — bright head + opacity-fading trail going
+ * upward, with hidden messages and rare glyph flashes. Externally
+ * controlled by `active`: true fades in, false fades out. Stays mounted
+ * for the duration of the parent so fade-out animates cleanly.
  *
- * When `active` goes true the canvas starts an RAF loop; when it goes
- * false the loop cancels and the canvas clears. Respects
- * prefers-reduced-motion — reduced users see a brief fade rather
- * than a scrolling animation.
+ * Positioned `fixed inset-0 z-30` so it overlays the entire viewport
+ * regardless of scroll. Pointer-events: none so clicks fall through.
  */
 export function IdleMatrixRain({ active }: IdleMatrixRainProps) {
   const canvasRef = useRef<HTMLCanvasElement>(null);
+  const activeRef = useRef(active);
+  activeRef.current = active;
   const prefersReducedMotion = useReducedMotion();
 
   useEffect(() => {
-    if (!active) return;
     const canvas = canvasRef.current;
     if (!canvas) return;
-
     const ctx = canvas.getContext('2d');
     if (!ctx) return;
 
-    // Match the canvas bitmap size to its CSS size (DPR aware).
+    const isMobile = window.innerWidth < 768;
+    const colWidth = isMobile ? COL_WIDTH * 2 : COL_WIDTH;
+
+    let w = 0;
+    let h = 0;
+    let columns: {
+      y: number;
+      speed: number;
+      message: string | null;
+      messageLife: number;
+    }[] = [];
+    let opacity = 0;
+    let rafId = 0;
+    let lastTime = 0;
+
     const resize = () => {
       const dpr = window.devicePixelRatio || 1;
-      const rect = canvas.getBoundingClientRect();
-      canvas.width = rect.width * dpr;
-      canvas.height = rect.height * dpr;
-      ctx.scale(dpr, dpr);
+      w = window.innerWidth;
+      h = window.innerHeight;
+      canvas.width = w * dpr;
+      canvas.height = h * dpr;
+      canvas.style.width = `${w}px`;
+      canvas.style.height = `${h}px`;
+      ctx.setTransform(dpr, 0, 0, dpr, 0, 0);
+
+      const numCols = Math.ceil(w / colWidth);
+      // Preserve existing column state on resize so a running rain
+      // doesn't reset every time the window changes size.
+      const next = Array.from({ length: numCols }, (_, i) =>
+        columns[i] ?? {
+          y: Math.random() * h,
+          speed: 40 + Math.random() * 80,
+          message: null as string | null,
+          messageLife: 0,
+        },
+      );
+      columns = next;
     };
+
     resize();
     window.addEventListener('resize', resize);
 
-    // Reduced-motion: paint a single quiet frame and bail.
+    // Reduced-motion: paint a single dim frame and bail. No animation.
     if (prefersReducedMotion) {
-      const rect = canvas.getBoundingClientRect();
-      ctx.fillStyle = 'rgba(0, 0, 0, 0.4)';
-      ctx.fillRect(0, 0, rect.width, rect.height);
-      return () => window.removeEventListener('resize', resize);
+      const [r, g, b] = getAccentRgb();
+      ctx.fillStyle = `rgba(${r}, ${g}, ${b}, 0.04)`;
+      ctx.fillRect(0, 0, w, h);
+      return () => {
+        window.removeEventListener('resize', resize);
+      };
     }
 
-    const fontSize = 14;
-    const rect = canvas.getBoundingClientRect();
-    const columns = Math.floor(rect.width / fontSize);
-    // Drops start uniformly distributed across the viewport height
-    // (expressed in rows) so the rain looks "full" the instant the
-    // user triggers it — previously we used Math.random() * -50 which
-    // meant ~12 seconds before columns were visible.
-    const rowsOnScreen = Math.ceil(rect.height / fontSize);
-    const drops: number[] = Array(columns)
-      .fill(0)
-      .map(() => Math.random() * rowsOnScreen);
-    // Per-column optional decoded-word state.
-    const words: Array<{ text: string; pos: number } | null> =
-      Array(columns).fill(null);
+    const draw = (now: number) => {
+      const dt = lastTime ? Math.min(0.05, (now - lastTime) / 1000) : 0.016;
+      lastTime = now;
 
-    let raf = 0;
-    const accentRgb = getComputedStyle(document.documentElement)
-      .getPropertyValue('--glow-color-rgb')
-      .trim() || '0, 255, 0';
-
-    const draw = () => {
-      const rect = canvas.getBoundingClientRect();
-      // Trail fade.
-      ctx.fillStyle = 'rgba(0, 0, 0, 0.08)';
-      ctx.fillRect(0, 0, rect.width, rect.height);
-
-      ctx.font = `${fontSize}px 'JetBrains Mono', 'Fira Code', monospace`;
-
-      for (let i = 0; i < columns; i++) {
-        // Occasionally begin a decoded word in this column.
-        if (!words[i] && Math.random() < 0.001) {
-          words[i] = {
-            text: HIDDEN_MESSAGES[Math.floor(Math.random() * HIDDEN_MESSAGES.length)],
-            pos: 0,
-          };
-        }
-
-        let glyph: string;
-        if (words[i]) {
-          glyph = words[i]!.text[words[i]!.pos];
-          words[i]!.pos++;
-          if (words[i]!.pos >= words[i]!.text.length) words[i] = null;
-          ctx.fillStyle = `rgb(${accentRgb})`;
-        } else {
-          glyph = GLYPHS[Math.floor(Math.random() * GLYPHS.length)];
-          ctx.fillStyle = `rgba(${accentRgb}, 0.6)`;
-        }
-
-        const x = i * fontSize;
-        const y = drops[i] * fontSize;
-        ctx.fillText(glyph, x, y);
-
-        if (y > rect.height && Math.random() > 0.975) {
-          drops[i] = 0;
-        }
-        drops[i]++;
+      const wantOn = activeRef.current;
+      if (wantOn && opacity < 1) {
+        opacity = Math.min(1, opacity + dt / (FADE_IN_MS / 1000));
+      } else if (!wantOn && opacity > 0) {
+        opacity = Math.max(0, opacity - dt / (FADE_OUT_MS / 1000));
       }
-      raf = requestAnimationFrame(draw);
+
+      // Stop the loop when fully transparent and not requested on. The
+      // next prop change will restart it via the activate effect below.
+      if (!wantOn && opacity <= 0) {
+        ctx.clearRect(0, 0, w, h);
+        lastTime = 0;
+        rafId = 0;
+        return;
+      }
+
+      const [r, g, b] = getAccentRgb();
+      ctx.clearRect(0, 0, w, h);
+      ctx.font = `${colWidth - 4}px 'JetBrains Mono', 'Fira Code', monospace`;
+      ctx.textAlign = 'center';
+
+      for (let i = 0; i < columns.length; i++) {
+        const col = columns[i];
+        col.y += col.speed * dt;
+
+        if (col.y > h + 40) {
+          col.y = -20;
+        }
+
+        // Per-frame chance to start a hidden message in this column,
+        // regardless of where its head currently is. Messages can pop
+        // in mid-screen instead of only at the top on wrap. Lifetime
+        // scales with length so the reader gets time to read.
+        if (!col.message && Math.random() < MESSAGE_CHANCE_PER_FRAME) {
+          const msg = HIDDEN_MESSAGES[Math.floor(Math.random() * HIDDEN_MESSAGES.length)];
+          col.message = msg;
+          col.messageLife =
+            MESSAGE_BASE_MS + msg.length * MESSAGE_MS_PER_CHAR + Math.random() * MESSAGE_JITTER_MS;
+        }
+
+        if (col.message) {
+          col.messageLife -= dt * 1000;
+          if (col.messageLife <= 0) {
+            col.message = null;
+            col.messageLife = 0;
+          }
+        }
+
+        const colX = i * colWidth + colWidth / 2;
+        const trailLen = 18;
+
+        for (let j = 0; j < trailLen; j++) {
+          const charY = col.y - j * (colWidth - 2);
+          if (charY < -20 || charY > h + 20) continue;
+
+          let ch: string;
+          if (col.message && j < col.message.length) {
+            ch = col.message[col.message.length - 1 - j];
+          } else {
+            ch = randomChar();
+          }
+
+          // Uniform fade — j=0 is the brightest point on the trail
+          // ramp (≈ 0.5 × opacity) but no longer gets a special "head"
+          // boost. The boosted head used to punch much brighter than
+          // the surrounding glyphs which read as inconsistent /
+          // distracting; a continuous ramp is calmer and easier on
+          // any theme.
+          const trailOpacity = (1 - j / trailLen) * 0.5 * opacity;
+          if (trailOpacity < 0.002) continue;
+          ctx.fillStyle = `rgba(${r}, ${g}, ${b}, ${trailOpacity})`;
+          ctx.fillText(ch, colX, charY);
+        }
+      }
+
+      rafId = requestAnimationFrame(draw);
     };
 
-    draw();
+    if (active) {
+      lastTime = 0;
+      rafId = requestAnimationFrame(draw);
+    }
 
     return () => {
-      cancelAnimationFrame(raf);
+      cancelAnimationFrame(rafId);
       window.removeEventListener('resize', resize);
-      // Clear on unmount so the overlay disappears cleanly.
-      const rect2 = canvas.getBoundingClientRect();
-      ctx.clearRect(0, 0, rect2.width, rect2.height);
+      ctx.clearRect(0, 0, w, h);
     };
+    // We only re-mount the loop when active flips. activeRef carries the
+    // live value into the running RAF so we don't need to restart on
+    // every change — but starting from "off" requires kicking the RAF.
   }, [active, prefersReducedMotion]);
 
-  if (!active) return null;
   return (
     <canvas
       ref={canvasRef}
       aria-hidden="true"
-      // Absolute inset-0 against the Terminal's outer shell (which is
-      // `position: relative; h-screen`), so the canvas covers the whole
-      // terminal viewport regardless of how far the user has scrolled
-      // the output pane. z-20 keeps it above scanlines + scrollback,
-      // below the command input and status bar.
-      className="pointer-events-none absolute inset-0 z-20 opacity-80"
+      className="pointer-events-none fixed inset-0 z-30"
     />
   );
 }

--- a/client/src/components/tui/IdleMatrixRain.tsx
+++ b/client/src/components/tui/IdleMatrixRain.tsx
@@ -1,0 +1,133 @@
+import { useEffect, useRef } from 'react';
+import { useReducedMotion } from 'framer-motion';
+
+interface IdleMatrixRainProps {
+  /** When true, the overlay is mounted and the rain animates. */
+  active: boolean;
+}
+
+const GLYPHS =
+  'アイウエオカキクケコサシスセソタチツテトナニヌネノハヒフヘホマミムメモヤユヨラリルレロワヲン0123456789';
+const HIDDEN_MESSAGES = [
+  'there is no spoon',
+  'wake up',
+  'stay curious',
+  'follow the white rabbit',
+  'decode me',
+];
+
+/**
+ * Matrix-style falling-glyph overlay scoped to the TUI output pane.
+ * Mirrors the GUI's `MatrixRain.tsx` as a lighter-weight terminal
+ * screensaver. Positioned absolutely over the terminal content,
+ * pointer-events: none so it doesn't steal clicks.
+ *
+ * When `active` goes true the canvas starts an RAF loop; when it goes
+ * false the loop cancels and the canvas clears. Respects
+ * prefers-reduced-motion — reduced users see a brief fade rather
+ * than a scrolling animation.
+ */
+export function IdleMatrixRain({ active }: IdleMatrixRainProps) {
+  const canvasRef = useRef<HTMLCanvasElement>(null);
+  const prefersReducedMotion = useReducedMotion();
+
+  useEffect(() => {
+    if (!active) return;
+    const canvas = canvasRef.current;
+    if (!canvas) return;
+
+    const ctx = canvas.getContext('2d');
+    if (!ctx) return;
+
+    // Match the canvas bitmap size to its CSS size (DPR aware).
+    const resize = () => {
+      const dpr = window.devicePixelRatio || 1;
+      const rect = canvas.getBoundingClientRect();
+      canvas.width = rect.width * dpr;
+      canvas.height = rect.height * dpr;
+      ctx.scale(dpr, dpr);
+    };
+    resize();
+    window.addEventListener('resize', resize);
+
+    // Reduced-motion: paint a single quiet frame and bail.
+    if (prefersReducedMotion) {
+      const rect = canvas.getBoundingClientRect();
+      ctx.fillStyle = 'rgba(0, 0, 0, 0.4)';
+      ctx.fillRect(0, 0, rect.width, rect.height);
+      return () => window.removeEventListener('resize', resize);
+    }
+
+    const fontSize = 14;
+    const rect = canvas.getBoundingClientRect();
+    const columns = Math.floor(rect.width / fontSize);
+    const drops: number[] = Array(columns).fill(0).map(() => Math.random() * -50);
+    // Per-column optional decoded-word state.
+    const words: Array<{ text: string; pos: number } | null> =
+      Array(columns).fill(null);
+
+    let raf = 0;
+    const accentRgb = getComputedStyle(document.documentElement)
+      .getPropertyValue('--glow-color-rgb')
+      .trim() || '0, 255, 0';
+
+    const draw = () => {
+      const rect = canvas.getBoundingClientRect();
+      // Trail fade.
+      ctx.fillStyle = 'rgba(0, 0, 0, 0.08)';
+      ctx.fillRect(0, 0, rect.width, rect.height);
+
+      ctx.font = `${fontSize}px 'JetBrains Mono', 'Fira Code', monospace`;
+
+      for (let i = 0; i < columns; i++) {
+        // Occasionally begin a decoded word in this column.
+        if (!words[i] && Math.random() < 0.001) {
+          words[i] = {
+            text: HIDDEN_MESSAGES[Math.floor(Math.random() * HIDDEN_MESSAGES.length)],
+            pos: 0,
+          };
+        }
+
+        let glyph: string;
+        if (words[i]) {
+          glyph = words[i]!.text[words[i]!.pos];
+          words[i]!.pos++;
+          if (words[i]!.pos >= words[i]!.text.length) words[i] = null;
+          ctx.fillStyle = `rgb(${accentRgb})`;
+        } else {
+          glyph = GLYPHS[Math.floor(Math.random() * GLYPHS.length)];
+          ctx.fillStyle = `rgba(${accentRgb}, 0.6)`;
+        }
+
+        const x = i * fontSize;
+        const y = drops[i] * fontSize;
+        ctx.fillText(glyph, x, y);
+
+        if (y > rect.height && Math.random() > 0.975) {
+          drops[i] = 0;
+        }
+        drops[i]++;
+      }
+      raf = requestAnimationFrame(draw);
+    };
+
+    draw();
+
+    return () => {
+      cancelAnimationFrame(raf);
+      window.removeEventListener('resize', resize);
+      // Clear on unmount so the overlay disappears cleanly.
+      const rect2 = canvas.getBoundingClientRect();
+      ctx.clearRect(0, 0, rect2.width, rect2.height);
+    };
+  }, [active, prefersReducedMotion]);
+
+  if (!active) return null;
+  return (
+    <canvas
+      ref={canvasRef}
+      aria-hidden="true"
+      className="pointer-events-none absolute inset-0 z-[5] opacity-70"
+    />
+  );
+}

--- a/client/src/components/tui/Kbd.tsx
+++ b/client/src/components/tui/Kbd.tsx
@@ -1,0 +1,30 @@
+import type { ReactNode } from 'react';
+
+interface KbdProps {
+  /** Content — typically a key label like `⌃K`, `↑↓`, `Esc`, `Tab`. */
+  children: ReactNode;
+  /** Make the chip more prominent — used for the currently-active
+      binding in a palette or status bar. */
+  active?: boolean;
+  className?: string;
+}
+
+/**
+ * Keyboard-key chip. Used in help, command palette, status bar, and
+ * reverse-search — wherever the UI surfaces a hotkey. The look is
+ * deliberately quiet: thin border, small uppercase mono text, barely
+ * any padding.
+ */
+export function Kbd({ children, active = false, className = '' }: KbdProps) {
+  return (
+    <kbd
+      className={`inline-flex items-center justify-center rounded-sm border px-1 py-[0.5px] font-mono text-[10px] leading-none tabular-nums
+        ${active
+          ? 'border-terminal-bright-green text-terminal-bright-green bg-terminal-bright-green/10'
+          : 'border-tui-accent-dim/60 text-tui-accent-dim'}
+        ${className}`}
+    >
+      {children}
+    </kbd>
+  );
+}

--- a/client/src/components/tui/LinkRegistry.tsx
+++ b/client/src/components/tui/LinkRegistry.tsx
@@ -1,0 +1,49 @@
+import { createContext, useContext, type ReactNode } from 'react';
+
+/**
+ * Terminal-wide numbered-link registry. Populated by `NumberedLink`
+ * as blocks render, drained by the `o N` / `g N` keyboard resolver
+ * in `Terminal.tsx`. Reset on `clear`.
+ *
+ * Numbers are assigned the first time a given `href` appears since
+ * the last reset and are stable across re-renders — typing `o 5`
+ * always opens the same link until cleared.
+ */
+
+export interface TerminalLink {
+  n: number;
+  href: string;
+  label: string;
+}
+
+export interface TerminalLinkRegistry {
+  /** Register a link, returning its assigned number. Duplicate hrefs
+   *  return the same number — a link appearing twice in the same
+   *  block reads as `[3]` both times. */
+  register: (href: string, label: string) => number;
+  resolve: (n: number) => TerminalLink | undefined;
+  /** Snapshot of all registered links (for the palette / debug). */
+  all: () => TerminalLink[];
+  /** Clear the registry. Called on `clearTerminal`. */
+  reset: () => void;
+}
+
+export const TerminalLinkContext = createContext<TerminalLinkRegistry | null>(null);
+
+export function useTerminalLinks(): TerminalLinkRegistry | null {
+  return useContext(TerminalLinkContext);
+}
+
+/** Thin wrapper so consumers import a single component instead of
+ *  dealing with raw context. */
+export function TerminalLinkProvider({
+  value,
+  children,
+}: {
+  value: TerminalLinkRegistry;
+  children: ReactNode;
+}) {
+  return (
+    <TerminalLinkContext.Provider value={value}>{children}</TerminalLinkContext.Provider>
+  );
+}

--- a/client/src/components/tui/MarkdownBlock.tsx
+++ b/client/src/components/tui/MarkdownBlock.tsx
@@ -1,0 +1,343 @@
+import { Fragment, type ReactNode } from 'react';
+
+/**
+ * Charm-Glow-style markdown renderer for the TUI.
+ *
+ * Handles the subset we actually use in the portfolio: headings
+ * (h1–h3), paragraphs, fenced code blocks (```), inline code,
+ * unordered + ordered lists, blockquotes, bold (**), italic (*),
+ * and [text](url) links. Output uses the new Block token palette:
+ * left-rail rules, sharp corners, accent-dim secondary.
+ *
+ * Why a hand-roll instead of `marked`: it's ~120 lines and keeps
+ * the output strictly JSX — no `dangerouslySetInnerHTML`, so the
+ * link registry (phase 7) can auto-register every anchor.
+ */
+
+interface MarkdownBlockProps {
+  /** The markdown source to render. */
+  source: string;
+  /** Tighter spacing — used inline in highlight bullets. */
+  inline?: boolean;
+}
+
+export function MarkdownBlock({ source, inline = false }: MarkdownBlockProps) {
+  const blocks = parseBlocks(source);
+  return (
+    <div className={inline ? 'space-y-1' : 'space-y-3'}>
+      {blocks.map((block, i) => (
+        <Fragment key={i}>{renderBlock(block)}</Fragment>
+      ))}
+    </div>
+  );
+}
+
+// ── Block-level parsing ──
+
+type Block =
+  | { kind: 'heading'; level: 1 | 2 | 3; text: string }
+  | { kind: 'code'; lang?: string; text: string }
+  | { kind: 'paragraph'; text: string }
+  | { kind: 'list'; ordered: boolean; items: string[] }
+  | { kind: 'blockquote'; text: string }
+  | { kind: 'hr' };
+
+function parseBlocks(src: string): Block[] {
+  const lines = src.replace(/\r\n?/g, '\n').split('\n');
+  const blocks: Block[] = [];
+  let i = 0;
+
+  while (i < lines.length) {
+    const line = lines[i];
+
+    // Fenced code block
+    if (/^```/.test(line)) {
+      const lang = line.slice(3).trim() || undefined;
+      const buf: string[] = [];
+      i++;
+      while (i < lines.length && !/^```/.test(lines[i])) {
+        buf.push(lines[i]);
+        i++;
+      }
+      i++; // closing fence
+      blocks.push({ kind: 'code', lang, text: buf.join('\n') });
+      continue;
+    }
+
+    // Headings
+    const h = /^(#{1,3})\s+(.+)$/.exec(line);
+    if (h) {
+      blocks.push({ kind: 'heading', level: h[1].length as 1 | 2 | 3, text: h[2].trim() });
+      i++;
+      continue;
+    }
+
+    // Horizontal rule
+    if (/^\s*(?:---+|\*\*\*+|___+)\s*$/.test(line)) {
+      blocks.push({ kind: 'hr' });
+      i++;
+      continue;
+    }
+
+    // Blockquote — collapse contiguous `> ` lines into one block.
+    if (/^>\s?/.test(line)) {
+      const buf: string[] = [];
+      while (i < lines.length && /^>\s?/.test(lines[i])) {
+        buf.push(lines[i].replace(/^>\s?/, ''));
+        i++;
+      }
+      blocks.push({ kind: 'blockquote', text: buf.join(' ') });
+      continue;
+    }
+
+    // Unordered list — `- item` or `* item`.
+    if (/^\s*[-*]\s+/.test(line)) {
+      const items: string[] = [];
+      while (i < lines.length && /^\s*[-*]\s+/.test(lines[i])) {
+        items.push(lines[i].replace(/^\s*[-*]\s+/, ''));
+        i++;
+      }
+      blocks.push({ kind: 'list', ordered: false, items });
+      continue;
+    }
+
+    // Ordered list — `1. item`.
+    if (/^\s*\d+\.\s+/.test(line)) {
+      const items: string[] = [];
+      while (i < lines.length && /^\s*\d+\.\s+/.test(lines[i])) {
+        items.push(lines[i].replace(/^\s*\d+\.\s+/, ''));
+        i++;
+      }
+      blocks.push({ kind: 'list', ordered: true, items });
+      continue;
+    }
+
+    // Blank line — separator, skip.
+    if (/^\s*$/.test(line)) {
+      i++;
+      continue;
+    }
+
+    // Paragraph — collect until blank line / next block.
+    const buf: string[] = [];
+    while (
+      i < lines.length &&
+      !/^\s*$/.test(lines[i]) &&
+      !/^#{1,3}\s/.test(lines[i]) &&
+      !/^```/.test(lines[i]) &&
+      !/^>\s?/.test(lines[i]) &&
+      !/^\s*[-*]\s+/.test(lines[i]) &&
+      !/^\s*\d+\.\s+/.test(lines[i])
+    ) {
+      buf.push(lines[i]);
+      i++;
+    }
+    blocks.push({ kind: 'paragraph', text: buf.join(' ') });
+  }
+
+  return blocks;
+}
+
+// ── Rendering ──
+
+function renderBlock(block: Block): ReactNode {
+  switch (block.kind) {
+    case 'heading':
+      return <Heading level={block.level} text={block.text} />;
+    case 'code':
+      return <CodeBlock lang={block.lang} text={block.text} />;
+    case 'paragraph':
+      return <p className="text-white/90 leading-relaxed">{renderInline(block.text)}</p>;
+    case 'list':
+      return (
+        <ul className="ml-1 space-y-1">
+          {block.items.map((item, i) => (
+            <li key={i} className="text-white/90 leading-relaxed flex gap-2">
+              <span className="text-tui-accent-dim shrink-0 mt-[2px]">
+                {block.ordered ? `${i + 1}.` : '·'}
+              </span>
+              <span className="flex-1">{renderInline(item)}</span>
+            </li>
+          ))}
+        </ul>
+      );
+    case 'blockquote':
+      return (
+        <blockquote className="border-l-2 border-tui-accent-dim/60 pl-3 italic text-white/80">
+          {renderInline(block.text)}
+        </blockquote>
+      );
+    case 'hr':
+      return <hr className="border-t border-tui-accent-dim/30" />;
+  }
+}
+
+function Heading({ level, text }: { level: 1 | 2 | 3; text: string }) {
+  if (level === 1) {
+    return (
+      <h1 className="flex items-baseline gap-2 text-terminal-bright-green font-bold text-base sm:text-lg">
+        <span aria-hidden="true" className="text-terminal-bright-green">▎</span>
+        <span>{renderInline(text)}</span>
+      </h1>
+    );
+  }
+  if (level === 2) {
+    return (
+      <h2 className="text-tui-accent-dim text-sm sm:text-base">
+        {/* Ratatui-style side-ruled heading */}
+        ── {renderInline(text)} ──
+      </h2>
+    );
+  }
+  return (
+    <h3 className="text-terminal-green text-sm">
+      <span aria-hidden="true" className="text-tui-accent-dim">· </span>
+      {renderInline(text)}
+    </h3>
+  );
+}
+
+function CodeBlock({ lang, text }: { lang?: string; text: string }) {
+  return (
+    <div className="relative border-l-2 border-tui-accent-dim/60 pl-3 bg-transparent font-mono text-xs leading-relaxed">
+      {lang && (
+        <div className="text-tui-muted text-[10px] mb-1 uppercase tracking-wide">
+          {lang}
+        </div>
+      )}
+      <pre className="text-terminal-green whitespace-pre-wrap break-words">{text}</pre>
+    </div>
+  );
+}
+
+// ── Inline parsing: code, link, bold, italic ──
+
+function renderInline(text: string): ReactNode {
+  // Tokenise in order of precedence. Code first (opaque), then links,
+  // then bold, then italic. Plain text is the fallback.
+  const tokens = tokeniseInline(text);
+  return tokens.map((t, i) => {
+    switch (t.kind) {
+      case 'code':
+        return (
+          <code
+            key={i}
+            className="text-terminal-bright-green bg-terminal-bright-green/10 px-1 py-0.5 border border-tui-accent-dim/30 text-[0.92em] font-mono"
+          >
+            {t.text}
+          </code>
+        );
+      case 'link':
+        return (
+          <a
+            key={i}
+            href={t.href}
+            target="_blank"
+            rel="noopener noreferrer"
+            className="text-terminal-bright-green underline hover:opacity-80 focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-terminal-bright-green"
+          >
+            {t.text}
+          </a>
+        );
+      case 'bold':
+        return (
+          <strong key={i} className="font-bold text-white">
+            {renderInline(t.text)}
+          </strong>
+        );
+      case 'italic':
+        return (
+          <em key={i} className="italic text-white/90">
+            {renderInline(t.text)}
+          </em>
+        );
+      case 'text':
+        return <Fragment key={i}>{t.text}</Fragment>;
+    }
+  });
+}
+
+type InlineToken =
+  | { kind: 'text'; text: string }
+  | { kind: 'code'; text: string }
+  | { kind: 'link'; text: string; href: string }
+  | { kind: 'bold'; text: string }
+  | { kind: 'italic'; text: string };
+
+function tokeniseInline(src: string): InlineToken[] {
+  const out: InlineToken[] = [];
+  let i = 0;
+  let buf = '';
+  const flushText = () => {
+    if (buf) {
+      out.push({ kind: 'text', text: buf });
+      buf = '';
+    }
+  };
+
+  while (i < src.length) {
+    const ch = src[i];
+
+    // Inline code — `…`
+    if (ch === '`') {
+      const end = src.indexOf('`', i + 1);
+      if (end !== -1) {
+        flushText();
+        out.push({ kind: 'code', text: src.slice(i + 1, end) });
+        i = end + 1;
+        continue;
+      }
+    }
+
+    // Link — [text](url)
+    if (ch === '[') {
+      const close = src.indexOf(']', i + 1);
+      if (close !== -1 && src[close + 1] === '(') {
+        const urlEnd = src.indexOf(')', close + 2);
+        if (urlEnd !== -1) {
+          const href = src.slice(close + 2, urlEnd);
+          if (/^https?:\/\//.test(href)) {
+            flushText();
+            out.push({ kind: 'link', text: src.slice(i + 1, close), href });
+            i = urlEnd + 1;
+            continue;
+          }
+        }
+      }
+    }
+
+    // Bold — **text**
+    if (ch === '*' && src[i + 1] === '*') {
+      const end = src.indexOf('**', i + 2);
+      if (end !== -1) {
+        flushText();
+        out.push({ kind: 'bold', text: src.slice(i + 2, end) });
+        i = end + 2;
+        continue;
+      }
+    }
+
+    // Italic — *text* (not part of **). Skip if adjacent asterisk.
+    if (ch === '*' && src[i + 1] !== '*') {
+      const end = indexOfItalicClose(src, i + 1);
+      if (end !== -1) {
+        flushText();
+        out.push({ kind: 'italic', text: src.slice(i + 1, end) });
+        i = end + 1;
+        continue;
+      }
+    }
+
+    buf += ch;
+    i++;
+  }
+  flushText();
+  return out;
+}
+
+function indexOfItalicClose(src: string, from: number): number {
+  for (let i = from; i < src.length; i++) {
+    if (src[i] === '*' && src[i + 1] !== '*') return i;
+  }
+  return -1;
+}

--- a/client/src/components/tui/NumberedLink.tsx
+++ b/client/src/components/tui/NumberedLink.tsx
@@ -6,41 +6,39 @@ interface NumberedLinkProps {
   /** Target URL. External links open in a new tab with noopener. */
   href: string;
   children: ReactNode;
-  /** Override the accessible label used by the `o N` resolver.
-      Defaults to the children if they are a plain string, else to
-      the href. */
+  /** Override the accessible label used by the `o N` / `open N`
+      resolver. Defaults to the children if they are a plain string,
+      else to the href. */
   label?: string;
-  /** Hide the `[N]` tag — used when the link is inline prose and the
-      tag would break the sentence. The link is still registered so
-      `o N` works; it just doesn't display its own number. */
+  /** Legacy prop — used to hide the inline `[N]` tag. The tag has
+      since been removed entirely (it was visual noise; the `open N`
+      command is hint enough), so this prop is now a no-op kept for
+      compatibility with existing call sites. */
   silent?: boolean;
   className?: string;
 }
 
 /**
  * External link that registers itself with the terminal-wide link
- * registry so the user can open it keyboard-only with `o N` / `g N`
- * (vim-motion). When rendered outside a registry (e.g., in a test or
- * standalone render) it degrades gracefully to a plain external
- * link without a number.
+ * registry so the user can still open it keyboard-only with the
+ * `open N` / `o N` / `g N` command. The visible `[N]` suffix has
+ * been removed — it cluttered outputs and the URL itself is the
+ * primary affordance.
  */
 export function NumberedLink({
   href,
   children,
   label,
-  silent = false,
   className = '',
 }: NumberedLinkProps) {
   const terminalRegistry = useTerminalLinks();
   const blockRegistry = useBlockLinks();
-  // Prefer terminal-wide registry (stable numbers across render).
-  // Fall back to the Block's per-render registry so legacy contexts
-  // keep working; finally no-op if neither is present.
   const registry = terminalRegistry ?? blockRegistry;
 
   const displayLabel =
     label ?? (typeof children === 'string' ? children : href);
-  const n = useMemo(
+  // Still register so `open N` keeps working — just don't display N.
+  useMemo(
     () => (registry ? registry.register(href, displayLabel) : null),
     [registry, href, displayLabel],
   );
@@ -50,18 +48,10 @@ export function NumberedLink({
       href={href}
       target="_blank"
       rel="noopener noreferrer"
-      aria-label={n !== null ? `${displayLabel} (link ${n})` : displayLabel}
+      aria-label={displayLabel}
       className={`text-terminal-bright-green underline hover:opacity-80 rounded-sm focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-terminal-bright-green ${className}`}
     >
       {children}
-      {n !== null && !silent && (
-        <span
-          aria-hidden="true"
-          className="ml-1 text-tui-muted text-[10px] sm:text-xs tabular-nums"
-        >
-          [{n}]
-        </span>
-      )}
     </a>
   );
 }

--- a/client/src/components/tui/NumberedLink.tsx
+++ b/client/src/components/tui/NumberedLink.tsx
@@ -50,6 +50,7 @@ export function NumberedLink({
       href={href}
       target="_blank"
       rel="noopener noreferrer"
+      aria-label={n !== null ? `${displayLabel} (link ${n})` : displayLabel}
       className={`text-terminal-bright-green underline hover:opacity-80 rounded-sm focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-terminal-bright-green ${className}`}
     >
       {children}

--- a/client/src/components/tui/NumberedLink.tsx
+++ b/client/src/components/tui/NumberedLink.tsx
@@ -1,0 +1,62 @@
+import { useMemo, type ReactNode } from 'react';
+import { useBlockLinks } from './Block';
+
+interface NumberedLinkProps {
+  /** Target URL. External links open in a new tab with noopener. */
+  href: string;
+  children: ReactNode;
+  /** Override the accessible label used by the `o N` resolver.
+      Defaults to the children if they are a plain string, else to
+      the href. */
+  label?: string;
+  /** Hide the `[N]` tag — used when the link is inline prose and the
+      tag would break the sentence. The link is still registered so
+      `o N` works; it just doesn't display its own number. */
+  silent?: boolean;
+  className?: string;
+}
+
+/**
+ * External link that registers itself with the enclosing `Block` so
+ * the user can open it with `o N` (vim-motion, wired in Phase 7).
+ * Outside a `Block`, this renders as a plain external link without a
+ * number — legacy contexts keep working.
+ */
+export function NumberedLink({
+  href,
+  children,
+  label,
+  silent = false,
+  className = '',
+}: NumberedLinkProps) {
+  const registry = useBlockLinks();
+  // useMemo so the registration is stable across re-renders within the
+  // same Block (Block's provider resets its counter per render, so the
+  // same link always claims the same number as long as render order is
+  // deterministic).
+  const displayLabel =
+    label ?? (typeof children === 'string' ? children : href);
+  const n = useMemo(
+    () => (registry ? registry.register(href, displayLabel) : null),
+    [registry, href, displayLabel],
+  );
+
+  return (
+    <a
+      href={href}
+      target="_blank"
+      rel="noopener noreferrer"
+      className={`text-terminal-bright-green underline hover:opacity-80 rounded-sm focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-terminal-bright-green ${className}`}
+    >
+      {children}
+      {n !== null && !silent && (
+        <span
+          aria-hidden="true"
+          className="ml-1 text-tui-muted text-[10px] sm:text-xs tabular-nums"
+        >
+          [{n}]
+        </span>
+      )}
+    </a>
+  );
+}

--- a/client/src/components/tui/NumberedLink.tsx
+++ b/client/src/components/tui/NumberedLink.tsx
@@ -1,5 +1,6 @@
 import { useMemo, type ReactNode } from 'react';
 import { useBlockLinks } from './Block';
+import { useTerminalLinks } from './LinkRegistry';
 
 interface NumberedLinkProps {
   /** Target URL. External links open in a new tab with noopener. */
@@ -17,10 +18,11 @@ interface NumberedLinkProps {
 }
 
 /**
- * External link that registers itself with the enclosing `Block` so
- * the user can open it with `o N` (vim-motion, wired in Phase 7).
- * Outside a `Block`, this renders as a plain external link without a
- * number — legacy contexts keep working.
+ * External link that registers itself with the terminal-wide link
+ * registry so the user can open it keyboard-only with `o N` / `g N`
+ * (vim-motion). When rendered outside a registry (e.g., in a test or
+ * standalone render) it degrades gracefully to a plain external
+ * link without a number.
  */
 export function NumberedLink({
   href,
@@ -29,11 +31,13 @@ export function NumberedLink({
   silent = false,
   className = '',
 }: NumberedLinkProps) {
-  const registry = useBlockLinks();
-  // useMemo so the registration is stable across re-renders within the
-  // same Block (Block's provider resets its counter per render, so the
-  // same link always claims the same number as long as render order is
-  // deterministic).
+  const terminalRegistry = useTerminalLinks();
+  const blockRegistry = useBlockLinks();
+  // Prefer terminal-wide registry (stable numbers across render).
+  // Fall back to the Block's per-render registry so legacy contexts
+  // keep working; finally no-op if neither is present.
+  const registry = terminalRegistry ?? blockRegistry;
+
   const displayLabel =
     label ?? (typeof children === 'string' ? children : href);
   const n = useMemo(

--- a/client/src/components/tui/ReplicatePage.tsx
+++ b/client/src/components/tui/ReplicatePage.tsx
@@ -9,108 +9,150 @@ export function ReplicatePage() {
   return (
     <>
       <Block title="// replicate" wide>
-        <div className="text-tui-muted text-xs mb-4">
-          clone this portfolio — drop in a resume.yaml, deploy. pick a path below.
+        {/* Pitch — sets the payoff + time before any steps. Two ETAs
+            because "have a resume?" vs "starting fresh?" diverge here. */}
+        <div className="text-white/80 text-xs sm:text-sm mb-1">
+          fork this portfolio. drop in a{' '}
+          <Code>resume.yaml</Code>, deploy.
+        </div>
+        <div className="text-tui-muted text-xs mb-5">
+          ~5 min if you have a resume · ~10 min from scratch
         </div>
 
-        <Subsection title="// ai converter">
-          <p className="text-white/80 mb-2">
-            already have a resume? convert it to YAML via AI in ~2 min.
-          </p>
-          <Steps>
-            <Step n={1}>get the ai conversion prompt (button below)</Step>
-            <Step n={2}>paste the prompt into ChatGPT / Claude / Gemini</Step>
-            <Step n={3}>attach or paste your existing resume (pdf, text, linkedin)</Step>
-            <Step n={4}>
-              ai generates yaml — save as{' '}
-              <Code>resume.yaml</Code>
-            </Step>
-          </Steps>
-          <div className="mt-3 flex items-center gap-3">
-            <button
-              type="button"
-              onClick={() => setModalOpen(true)}
-              className="border border-terminal-bright-green px-3 py-1 text-terminal-bright-green hover:bg-terminal-bright-green/10 transition-colors text-xs font-mono focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-terminal-bright-green"
-            >
-              get conversion prompt
-            </button>
-            <span className="text-tui-muted text-xs">
-              works with any ai assistant
+        {/* ── Step 1 ── */}
+        <PhaseHeader n={1} title="get your resume.yaml" eta="~2 min" />
+        <PhaseBody>
+          {/* Dominant CTA — most visitors arrive with a resume in some
+              form. The button doesn't convert anything itself — it
+              hands you the prompt to feed your AI of choice. The
+              label spells that out so users don't expect in-page
+              magic. */}
+          <button
+            type="button"
+            onClick={() => setModalOpen(true)}
+            className="group w-full sm:w-auto inline-flex items-center gap-3 border-2 border-terminal-bright-green bg-terminal-bright-green/15 hover:bg-terminal-bright-green/25 px-4 py-2.5 text-terminal-bright-green transition-colors font-mono focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-terminal-bright-green shadow-[0_0_14px_rgba(var(--glow-color-rgb),0.35)]"
+          >
+            <span className="text-base font-bold tracking-wide">
+              [&nbsp;get ai prompt&nbsp;]
             </span>
-          </div>
-        </Subsection>
+            <span className="text-xs text-terminal-bright-green/80">
+              copy → paste into chatgpt / claude / gemini
+            </span>
+            <span
+              aria-hidden="true"
+              className="ml-auto text-base text-terminal-bright-green transition-transform group-hover:translate-x-0.5"
+            >
+              →
+            </span>
+          </button>
 
-        <Subsection title="// easy mode">
-          <p className="text-white/80 mb-2">
-            zero-code deploy — everything auto-generates from your resume.yaml.
-          </p>
+          <ul className="mt-3 space-y-1 text-xs sm:text-sm text-white/80 list-none">
+            <AltRow>
+              <NumberedLink href="https://app.rendercv.com">rendercv builder</NumberedLink>
+              <span className="text-tui-muted"> — start from scratch in your browser</span>
+            </AltRow>
+            <AltRow>
+              <span className="text-terminal-bright-green">write yaml manually</span>
+              <span className="text-tui-muted"> — see schema in </span>
+              <NumberedLink href="https://github.com/subhayu99/subhayu99.github.io/blob/main/docs/ADVANCED.md">
+                ADVANCED.md
+              </NumberedLink>
+            </AltRow>
+          </ul>
+        </PhaseBody>
+
+        {/* ── Step 2 ── */}
+        <PhaseHeader n={2} title="deploy" eta="~3 min" />
+        <PhaseBody>
+          {/* Default path: zero-code via template. The advanced path is
+              tucked inside <details> below to keep the easy flow clean. */}
           <Steps>
             <Step n={1}>
-              create{' '}
-              <Code>resume.yaml</Code>
-              {' '}(use{' '}
-              <NumberedLink href="https://app.rendercv.com">rendercv</NumberedLink>{' '}
-              or ai, above)
-            </Step>
-            <Step n={2}>
               click{' '}
               <NumberedLink href="https://github.com/subhayu99/subhayu99.github.io/generate">
                 "use this template"
               </NumberedLink>
               {' '}→ name it{' '}
-              <Code>yourusername.github.io</Code>
-            </Step>
-            <Step n={3}>
-              enable actions + pages:{' '}
-              <span className="text-tui-accent-dim">settings → pages → deploy from actions</span>
-              <div className="text-tui-warn/80 text-xs mt-1">
-                ! do this before uploading resume or the first build errors
+              <Code>&lt;your-username&gt;.github.io</Code>
+              <div className="text-tui-muted text-[11px] mt-1">
+                replace <Code>&lt;your-username&gt;</Code> with your actual github handle
+                — angle brackets aren't part of the name.
               </div>
             </Step>
-            <Step n={4}>
+            <Step n={2}>
+              <Callout>
+                <div className="font-semibold text-tui-warn">
+                  ⚠ enable actions + pages BEFORE uploading your resume
+                </div>
+                <div className="text-white/80 mt-1">
+                  settings → actions → general → allow all
+                  <br />
+                  settings → pages → source: deploy from actions
+                </div>
+                <div className="text-tui-muted text-[11px] mt-1">
+                  skip this and the first build errors out — common gotcha.
+                </div>
+              </Callout>
+            </Step>
+            <Step n={3}>
               upload{' '}
               <Code>resume.yaml</Code>
-              {' '}to the repo — deploy fires automatically.
+              {' '}to the repo — the deploy action fires automatically.
             </Step>
           </Steps>
-          <div className="mt-3 border-l-2 border-tui-accent-dim/50 pl-3 text-xs text-white/80">
-            <div className="text-tui-accent-dim mb-1">auto-generated:</div>
-            <ul className="space-y-0.5 list-none">
-              <li>· ascii art name banner</li>
-              <li>· pwa manifest.json</li>
-              <li>· pdf resume</li>
-              <li>· neofetch banner (if custom not provided)</li>
-            </ul>
-          </div>
-        </Subsection>
 
-        <Subsection title="// advanced mode">
-          <p className="text-white/80 mb-2">
-            full control over themes, commands, features. npm + git.
-          </p>
-          <Steps>
-            <Step n={1}>
-              clone + install:
-              <Pre>
+          {/* Advanced — collapsed by default. Native <details> for zero
+              JS, accessible by default, keyboard-friendly. */}
+          <details className="group mt-4 border-t border-tui-accent-dim/30 pt-3">
+            <summary className="cursor-pointer text-xs sm:text-sm text-tui-accent-dim hover:text-terminal-bright-green flex items-center gap-2 list-none focus-visible:outline-none focus-visible:text-terminal-bright-green">
+              <span className="font-mono text-terminal-bright-green w-3">
+                <span className="group-open:hidden">+</span>
+                <span className="hidden group-open:inline">−</span>
+              </span>
+              <span>advanced (full control — clone + npm)</span>
+            </summary>
+            <div className="mt-3 pl-5">
+              <Steps>
+                <Step n={1}>
+                  clone + install:
+                  <Pre>
 {`git clone https://github.com/subhayu99/subhayu99.github.io.git
 cd subhayu99.github.io
 npm install`}
-              </Pre>
-            </Step>
-            <Step n={2}>
-              copy configs:
-              <Pre>
+                  </Pre>
+                </Step>
+                <Step n={2}>
+                  copy configs:
+                  <Pre>
 {`cp template.config.yaml.example template.config.yaml
 cp .env.example .env
 cp client/public/manifest.json.example client/public/manifest.json`}
-              </Pre>
-            </Step>
-            <Step n={3}>add your resume + customise themes / commands</Step>
-            <Step n={4}>push + enable github pages</Step>
-          </Steps>
-        </Subsection>
+                  </Pre>
+                </Step>
+                <Step n={3}>add your resume + customise themes / commands</Step>
+                <Step n={4}>push + enable github pages</Step>
+              </Steps>
+            </div>
+          </details>
+        </PhaseBody>
 
-        <div className="mt-4 pt-3 border-t border-tui-accent-dim/30">
+        {/* ── What you get ── (named phase, no number — it's the payoff
+             not a step). Lands before docs so the user sees the reward
+             before scrolling into reference links. */}
+        <PhaseHeader title="what you get" />
+        <PhaseBody>
+          <div className="text-xs sm:text-sm text-white/80 grid grid-cols-1 sm:grid-cols-2 gap-x-6 gap-y-1">
+            <Bullet>live at <Code>&lt;your-username&gt;.github.io</Code></Bullet>
+            <Bullet>pwa-installable (offline-ready)</Bullet>
+            <Bullet>auto-rendered pdf resume</Bullet>
+            <Bullet>ascii name banner</Bullet>
+            <Bullet>neofetch system info</Bullet>
+            <Bullet>themes + custom commands</Bullet>
+          </div>
+        </PhaseBody>
+
+        {/* ── Help / docs ── */}
+        <div className="mt-2 pt-3 border-t border-tui-accent-dim/30">
           <div className="text-tui-accent-dim text-xs mb-2">// docs</div>
           <div className="grid grid-cols-1 sm:grid-cols-2 gap-x-4 gap-y-1 text-xs">
             <NumberedLink href="https://github.com/subhayu99/subhayu99.github.io#readme">
@@ -142,29 +184,78 @@ cp client/public/manifest.json.example client/public/manifest.json`}
 
 // ── Small primitives used only by this page ──
 
-function Subsection({ title, children }: { title: string; children: React.ReactNode }) {
+/** Numbered phase header — `// step N — title` with optional ETA on the right. */
+function PhaseHeader({
+  n,
+  title,
+  eta,
+}: {
+  n?: number;
+  title: string;
+  eta?: string;
+}) {
   return (
-    <div className="mb-4">
-      <div className="text-tui-accent-dim text-xs mb-2">{title}</div>
-      <div className="pl-2 border-l-2 border-tui-accent-dim/30 text-xs sm:text-sm">
-        {children}
+    <div className="mt-5 mb-2 flex items-baseline justify-between gap-2">
+      <div className="text-terminal-bright-green text-xs sm:text-sm font-mono tracking-wide">
+        // {n != null ? `step ${n} — ` : ''}{title}
       </div>
+      {eta && (
+        <div className="text-tui-muted text-[10px] sm:text-xs tabular-nums whitespace-nowrap">
+          {eta}
+        </div>
+      )}
     </div>
   );
 }
 
+/** Body of a phase — left rail + indent so phases visually group. */
+function PhaseBody({ children }: { children: React.ReactNode }) {
+  return (
+    <div className="pl-3 border-l-2 border-tui-accent-dim/30">{children}</div>
+  );
+}
+
 function Steps({ children }: { children: React.ReactNode }) {
-  return <ol className="space-y-1.5 ml-1 list-none">{children}</ol>;
+  return <ol className="space-y-2 list-none">{children}</ol>;
 }
 
 function Step({ n, children }: { n: number; children: React.ReactNode }) {
   return (
     <li className="flex items-start gap-2">
-      <span className="text-terminal-bright-green tabular-nums font-mono">
+      <span className="text-terminal-bright-green tabular-nums font-mono text-xs sm:text-sm">
         {n}.
       </span>
-      <div className="text-white flex-1 leading-relaxed">{children}</div>
+      <div className="text-white/90 flex-1 leading-relaxed text-xs sm:text-sm">
+        {children}
+      </div>
     </li>
+  );
+}
+
+function AltRow({ children }: { children: React.ReactNode }) {
+  return (
+    <li className="flex items-start gap-2">
+      <span className="text-tui-accent-dim mt-[2px]">·</span>
+      <div className="flex-1">{children}</div>
+    </li>
+  );
+}
+
+function Bullet({ children }: { children: React.ReactNode }) {
+  return (
+    <div className="flex items-start gap-2">
+      <span className="text-terminal-bright-green mt-[1px]">·</span>
+      <div className="flex-1">{children}</div>
+    </div>
+  );
+}
+
+/** Boxed warning — louder than a one-line tip, scoped to a step. */
+function Callout({ children }: { children: React.ReactNode }) {
+  return (
+    <div className="border border-tui-warn/40 bg-tui-warn/[0.04] px-3 py-2 text-xs sm:text-sm">
+      {children}
+    </div>
   );
 }
 

--- a/client/src/components/tui/ReplicatePage.tsx
+++ b/client/src/components/tui/ReplicatePage.tsx
@@ -1,292 +1,190 @@
 import { useEffect, useRef, useState } from 'react';
 import { apiConfig } from '../../config';
-import { SectionBox } from './SectionBox';
-import { ExtLink } from './TuiLink';
+import { Block } from './Block';
+import { NumberedLink } from './NumberedLink';
 
 export function ReplicatePage() {
   const [modalOpen, setModalOpen] = useState(false);
 
   return (
     <>
-      <SectionBox
-        title="CREATE YOUR OWN TERMINAL PORTFOLIO"
-        centerTitle
-        bodyClassName="p-4 space-y-4 text-sm"
-      >
-        <AiConverterSection onOpenModal={() => setModalOpen(true)} />
-        <EasyModeSection />
-        <AdvancedModeSection />
-        <CTASection />
-        <QuickLinks />
-        <Footer />
-      </SectionBox>
+      <Block title="// replicate" wide>
+        <div className="text-tui-muted text-xs mb-4">
+          clone this portfolio — drop in a resume.yaml, deploy. pick a path below.
+        </div>
+
+        <Subsection title="// ai converter">
+          <p className="text-white/80 mb-2">
+            already have a resume? convert it to YAML via AI in ~2 min.
+          </p>
+          <Steps>
+            <Step n={1}>get the ai conversion prompt (button below)</Step>
+            <Step n={2}>paste the prompt into ChatGPT / Claude / Gemini</Step>
+            <Step n={3}>attach or paste your existing resume (pdf, text, linkedin)</Step>
+            <Step n={4}>
+              ai generates yaml — save as{' '}
+              <Code>resume.yaml</Code>
+            </Step>
+          </Steps>
+          <div className="mt-3 flex items-center gap-3">
+            <button
+              type="button"
+              onClick={() => setModalOpen(true)}
+              className="border border-terminal-bright-green px-3 py-1 text-terminal-bright-green hover:bg-terminal-bright-green/10 transition-colors text-xs font-mono focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-terminal-bright-green"
+            >
+              get conversion prompt
+            </button>
+            <span className="text-tui-muted text-xs">
+              works with any ai assistant
+            </span>
+          </div>
+        </Subsection>
+
+        <Subsection title="// easy mode">
+          <p className="text-white/80 mb-2">
+            zero-code deploy — everything auto-generates from your resume.yaml.
+          </p>
+          <Steps>
+            <Step n={1}>
+              create{' '}
+              <Code>resume.yaml</Code>
+              {' '}(use{' '}
+              <NumberedLink href="https://app.rendercv.com">rendercv</NumberedLink>{' '}
+              or ai, above)
+            </Step>
+            <Step n={2}>
+              click{' '}
+              <NumberedLink href="https://github.com/subhayu99/subhayu99.github.io/generate">
+                "use this template"
+              </NumberedLink>
+              {' '}→ name it{' '}
+              <Code>yourusername.github.io</Code>
+            </Step>
+            <Step n={3}>
+              enable actions + pages:{' '}
+              <span className="text-tui-accent-dim">settings → pages → deploy from actions</span>
+              <div className="text-tui-warn/80 text-xs mt-1">
+                ! do this before uploading resume or the first build errors
+              </div>
+            </Step>
+            <Step n={4}>
+              upload{' '}
+              <Code>resume.yaml</Code>
+              {' '}to the repo — deploy fires automatically.
+            </Step>
+          </Steps>
+          <div className="mt-3 border-l-2 border-tui-accent-dim/50 pl-3 text-xs text-white/80">
+            <div className="text-tui-accent-dim mb-1">auto-generated:</div>
+            <ul className="space-y-0.5 list-none">
+              <li>· ascii art name banner</li>
+              <li>· pwa manifest.json</li>
+              <li>· pdf resume</li>
+              <li>· neofetch banner (if custom not provided)</li>
+            </ul>
+          </div>
+        </Subsection>
+
+        <Subsection title="// advanced mode">
+          <p className="text-white/80 mb-2">
+            full control over themes, commands, features. npm + git.
+          </p>
+          <Steps>
+            <Step n={1}>
+              clone + install:
+              <Pre>
+{`git clone https://github.com/subhayu99/subhayu99.github.io.git
+cd subhayu99.github.io
+npm install`}
+              </Pre>
+            </Step>
+            <Step n={2}>
+              copy configs:
+              <Pre>
+{`cp template.config.yaml.example template.config.yaml
+cp .env.example .env
+cp client/public/manifest.json.example client/public/manifest.json`}
+              </Pre>
+            </Step>
+            <Step n={3}>add your resume + customise themes / commands</Step>
+            <Step n={4}>push + enable github pages</Step>
+          </Steps>
+        </Subsection>
+
+        <div className="mt-4 pt-3 border-t border-tui-accent-dim/30">
+          <div className="text-tui-accent-dim text-xs mb-2">// docs</div>
+          <div className="grid grid-cols-1 sm:grid-cols-2 gap-x-4 gap-y-1 text-xs">
+            <NumberedLink href="https://github.com/subhayu99/subhayu99.github.io#readme">
+              easy mode guide
+            </NumberedLink>
+            <NumberedLink href="https://github.com/subhayu99/subhayu99.github.io/blob/main/docs/ADVANCED.md">
+              advanced customisation
+            </NumberedLink>
+            <NumberedLink href="https://app.rendercv.com">
+              rendercv builder
+            </NumberedLink>
+            <NumberedLink href="https://github.com/subhayu99/subhayu99.github.io/blob/main/docs/TROUBLESHOOTING.md">
+              troubleshooting
+            </NumberedLink>
+          </div>
+        </div>
+
+        <div className="mt-4 pt-3 border-t border-tui-accent-dim/30 text-center text-xs text-tui-muted">
+          built with love and a little obsession ·{' '}
+          <NumberedLink href="https://github.com/subhayu99/subhayu99.github.io">
+            star on github
+          </NumberedLink>
+        </div>
+      </Block>
       {modalOpen && <AIPromptModal onClose={() => setModalOpen(false)} />}
     </>
   );
 }
 
-function AiConverterSection({ onOpenModal }: { onOpenModal: () => void }) {
+// ── Small primitives used only by this page ──
+
+function Subsection({ title, children }: { title: string; children: React.ReactNode }) {
   return (
-    <div className="border border-terminal-bright-green/40 rounded p-3 bg-terminal-bright-green/10">
-      <div className="text-terminal-bright-green font-bold text-base mb-2 flex items-center gap-2">
-        <span>🔄 AI-POWERED RESUME CONVERTER</span>
-        <span className="text-xs bg-terminal-bright-green/30 px-2 py-0.5 rounded">
-          ⚡ Fastest method
-        </span>
-      </div>
-      <div className="text-terminal-green mb-3">
-        <strong>Already have a resume?</strong> Convert it to YAML format using AI in ~2 minutes. No
-        manual typing!
-      </div>
-      <ol className="space-y-2 ml-3 text-sm">
-        <Step n={1} accent="bright-green">
-          Click the button below to get the AI conversion prompt
-        </Step>
-        <Step n={2} accent="bright-green">
-          Copy the prompt and paste it into ChatGPT/Claude/Gemini
-        </Step>
-        <Step n={3} accent="bright-green">
-          Attach or paste your existing resume (PDF, text, or LinkedIn)
-        </Step>
-        <Step n={4} accent="bright-green">
-          AI generates perfect YAML — save as{' '}
-          <code className="text-terminal-bright-green bg-black/30 px-1">resume.yaml</code>
-        </Step>
-      </ol>
-      <div className="mt-3 flex flex-col sm:flex-row gap-2 items-start sm:items-center">
-        <button
-          type="button"
-          onClick={onOpenModal}
-          className="bg-terminal-bright-green/20 hover:bg-terminal-bright-green/30 border border-terminal-bright-green/50 px-4 py-2 rounded text-terminal-bright-green font-semibold transition-all duration-200 hover:scale-105 cursor-pointer focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-terminal-bright-green"
-        >
-          📋 Get AI Conversion Prompt
-        </button>
-        <div className="text-xs text-terminal-bright-green/70">
-          Works with any AI assistant (ChatGPT, Claude, Gemini)
-        </div>
-      </div>
-      <div className="mt-3 pt-3 border-t border-terminal-bright-green/20 text-xs text-terminal-green flex flex-wrap items-center gap-3">
-        <span>⚡ ~2 minutes</span>
-        <span>🤖 AI-powered</span>
-        <span>💯 Perfect formatting</span>
-        <span>📝 Supports any resume format</span>
+    <div className="mb-4">
+      <div className="text-tui-accent-dim text-xs mb-2">{title}</div>
+      <div className="pl-2 border-l-2 border-tui-accent-dim/30 text-xs sm:text-sm">
+        {children}
       </div>
     </div>
   );
 }
 
-function EasyModeSection() {
-  return (
-    <div className="border border-terminal-yellow/30 rounded p-3 bg-terminal-yellow/5">
-      <div className="text-terminal-yellow font-bold text-base mb-3 flex items-center gap-2">
-        <span>🌟 EASY MODE</span>
-        <span className="text-xs bg-terminal-yellow/20 px-2 py-0.5 rounded">Zero-code setup</span>
-      </div>
-      <div className="text-terminal-green mb-3">
-        <strong>True zero-code deployment!</strong> Everything auto-generates — just upload your
-        resume YAML.
-      </div>
-      <ol className="space-y-2 ml-3">
-        <Step n={1} accent="yellow">
-          Create <code className="text-terminal-bright-green bg-black/30 px-1">resume.yaml</code>{' '}
-          (use{' '}
-          <ExtLink href="https://app.rendercv.com" className="text-terminal-bright-green">
-            RenderCV
-          </ExtLink>{' '}
-          or AI — see above)
-        </Step>
-        <Step n={2} accent="yellow">
-          Click{' '}
-          <ExtLink
-            href="https://github.com/subhayu99/subhayu99.github.io/generate"
-            className="text-terminal-bright-green"
-          >
-            "Use this template"
-          </ExtLink>{' '}
-          → Name it{' '}
-          <code className="text-terminal-bright-green bg-black/30 px-1">
-            yourusername.github.io
-          </code>
-        </Step>
-        <Step n={3} accent="yellow">
-          Enable GitHub Actions &amp; Pages:{' '}
-          <span className="text-terminal-yellow">Settings → Pages → Deploy from Actions</span>
-          <div className="text-terminal-yellow/70 text-xs mt-1">
-            ⚠️ Do this BEFORE uploading resume to avoid errors!
-          </div>
-        </Step>
-        <Step n={4} accent="yellow">
-          Upload your{' '}
-          <code className="text-terminal-bright-green bg-black/30 px-1">resume.yaml</code> to the
-          repo — deployment starts automatically!
-        </Step>
-      </ol>
-      <div className="mt-3 p-2 bg-black/30 rounded border border-terminal-green/30">
-        <div className="text-terminal-bright-green font-bold text-xs mb-1">
-          ✨ Auto-Generated Features:
-        </div>
-        <div className="text-terminal-green/80 text-xs space-y-0.5 ml-2">
-          <div>• ASCII art name banner (from your name)</div>
-          <div>• PWA manifest.json (installable app)</div>
-          <div>• PDF resume (formatted and downloadable)</div>
-          <div>• Neofetch banner (if custom file not provided)</div>
-        </div>
-      </div>
-      <div className="mt-3 pt-3 border-t border-terminal-yellow/20 text-xs text-terminal-green flex items-center justify-between gap-3 flex-wrap">
-        <span>⏱️ Time: ~5 min</span>
-        <span>✨ Auto-Generated</span>
-        <span>💰 Free Forever</span>
-        <span>💻 Zero Code</span>
-      </div>
-    </div>
-  );
+function Steps({ children }: { children: React.ReactNode }) {
+  return <ol className="space-y-1.5 ml-1 list-none">{children}</ol>;
 }
 
-function AdvancedModeSection() {
+function Step({ n, children }: { n: number; children: React.ReactNode }) {
   return (
-    <div className="border border-terminal-green/30 rounded p-3 bg-terminal-green/5">
-      <div className="text-terminal-bright-green font-bold text-base mb-3">🔧 ADVANCED MODE</div>
-      <div className="text-terminal-green mb-3">
-        Full control over themes, commands, and features. Requires npm/git knowledge.
-      </div>
-      <ol className="space-y-2 ml-3">
-        <Step n={1} accent="green">
-          <div>
-            Clone the template and install dependencies:
-            <pre className="bg-black/50 rounded p-2 mt-1 font-mono text-xs text-terminal-green whitespace-pre-wrap">
-{`git clone https://github.com/subhayu99/subhayu99.github.io.git
-cd subhayu99.github.io
-npm install`}
-            </pre>
-          </div>
-        </Step>
-        <Step n={2} accent="green">
-          <div>
-            Copy and customize config files:
-            <pre className="bg-black/50 rounded p-2 mt-1 font-mono text-xs text-terminal-green whitespace-pre-wrap">
-{`cp template.config.yaml.example template.config.yaml
-cp .env.example .env
-cp client/public/manifest.json.example client/public/manifest.json`}
-            </pre>
-          </div>
-        </Step>
-        <Step n={3} accent="green">
-          Add your resume and customize themes/commands
-          <div className="text-terminal-green/70 text-xs mt-1">
-            ✓ See ADVANCED.md for customization guide
-          </div>
-        </Step>
-        <Step n={4} accent="green">
-          Deploy to GitHub Pages
-          <div className="text-terminal-green/70 text-xs mt-1">
-            ✓ Push to GitHub and enable Actions
-          </div>
-        </Step>
-      </ol>
-    </div>
-  );
-}
-
-function CTASection() {
-  return (
-    <div className="border border-terminal-bright-green/40 rounded p-3 bg-terminal-green/5 text-center">
-      <div className="text-terminal-bright-green font-bold text-base mb-2">
-        🚀 Ready to Create Your Portfolio?
-      </div>
-      <div className="flex flex-col sm:flex-row items-center justify-center gap-3">
-        <a
-          href="https://github.com/subhayu99/subhayu99.github.io/generate"
-          target="_blank"
-          rel="noopener noreferrer"
-          className="inline-block bg-terminal-green/20 hover:bg-terminal-green/30 border border-terminal-green text-terminal-bright-green font-bold px-4 py-2 rounded transition-all duration-200 hover:scale-105"
-        >
-          ⚡ Get Started Now
-        </a>
-        <span className="text-terminal-green/70 text-xs">
-          ~5 minutes • Zero coding required
-        </span>
-      </div>
-    </div>
-  );
-}
-
-function QuickLinks() {
-  const links = [
-    { href: 'https://github.com/subhayu99/subhayu99.github.io#readme', text: '📖 Easy Mode Guide' },
-    {
-      href: 'https://github.com/subhayu99/subhayu99.github.io/blob/main/docs/ADVANCED.md',
-      text: '🔧 Advanced Customization',
-    },
-    { href: 'https://app.rendercv.com', text: '🎨 RenderCV Builder' },
-    {
-      href: 'https://github.com/subhayu99/subhayu99.github.io/blob/main/docs/TROUBLESHOOTING.md',
-      text: '🛟 Troubleshooting',
-    },
-  ];
-  return (
-    <div className="border-t border-terminal-green/30 pt-3 mt-3">
-      <div className="text-terminal-bright-green font-bold mb-2">📚 Documentation &amp; Help</div>
-      <div className="grid grid-cols-2 gap-2 text-xs ml-3">
-        {links.map((l) => (
-          <div key={l.href}>
-            <a
-              href={l.href}
-              target="_blank"
-              rel="noopener noreferrer"
-              className="text-terminal-yellow hover:text-terminal-yellow hover:underline transition-colors duration-200"
-            >
-              {l.text}
-            </a>
-          </div>
-        ))}
-      </div>
-    </div>
-  );
-}
-
-function Footer() {
-  return (
-    <div className="text-center text-xs text-terminal-green/70 border-t border-terminal-green/20 pt-3 space-y-1">
-      <div>⚡ Built with ❤️ by developers, for developers</div>
-      <div className="flex items-center justify-center gap-4 flex-wrap">
-        <a
-          href="https://github.com/subhayu99/subhayu99.github.io"
-          target="_blank"
-          rel="noopener noreferrer"
-          className="text-terminal-yellow hover:text-terminal-yellow hover:underline transition-colors duration-200"
-        >
-          ⭐ Star on GitHub
-        </a>
-        <span>•</span>
-        <span>🤖 AI-Assisted Setup</span>
-        <span>•</span>
-        <span>✨ Auto-Generated</span>
-      </div>
-    </div>
-  );
-}
-
-function Step({
-  n,
-  accent,
-  children,
-}: {
-  n: number;
-  accent: 'bright-green' | 'yellow' | 'green';
-  children: React.ReactNode;
-}) {
-  const colorMap: Record<typeof accent, string> = {
-    'bright-green': 'text-terminal-bright-green',
-    yellow: 'text-terminal-yellow',
-    green: 'text-terminal-green',
-  };
-  return (
-    <li className="flex items-start gap-2 list-none">
-      <span className={`${colorMap[accent]} font-bold`}>{n}.</span>
-      <div className="text-white flex-1">{children}</div>
+    <li className="flex items-start gap-2">
+      <span className="text-terminal-bright-green tabular-nums font-mono">
+        {n}.
+      </span>
+      <div className="text-white flex-1 leading-relaxed">{children}</div>
     </li>
   );
 }
+
+function Code({ children }: { children: React.ReactNode }) {
+  return (
+    <code className="text-terminal-bright-green bg-terminal-bright-green/10 px-1 py-0.5 text-xs border border-tui-accent-dim/30">
+      {children}
+    </code>
+  );
+}
+
+function Pre({ children }: { children: React.ReactNode }) {
+  return (
+    <pre className="border-l-2 border-tui-accent-dim/50 mt-1.5 pl-3 font-mono text-[11px] sm:text-xs text-terminal-green whitespace-pre-wrap">
+      {children}
+    </pre>
+  );
+}
+
+// ── AI prompt modal ──
 
 function AIPromptModal({ onClose }: { onClose: () => void }) {
   const [promptText, setPromptText] = useState<string | null>(null);
@@ -355,90 +253,79 @@ function AIPromptModal({ onClose }: { onClose: () => void }) {
       onClick={(e) => {
         if (e.target === e.currentTarget) onClose();
       }}
-      className="fixed inset-0 bg-black/80 backdrop-blur-sm z-50 flex items-center justify-center p-4"
+      className="fixed inset-0 bg-black/85 z-50 flex items-center justify-center p-4"
     >
       <div
         ref={dialogRef}
         tabIndex={-1}
-        className="bg-terminal-black border-2 border-terminal-bright-green rounded-lg max-w-4xl w-full max-h-[85vh] flex flex-col shadow-2xl outline-none"
+        className="relative bg-terminal-black border border-tui-accent-dim/50 border-l-[3px] border-l-terminal-bright-green max-w-4xl w-full max-h-[85vh] flex flex-col outline-none terminal-glow"
       >
-        <div className="border-b border-terminal-bright-green/50 px-4 py-3 flex items-center justify-between bg-terminal-bright-green/10">
-          <div className="flex items-center gap-3">
-            <span className="text-terminal-bright-green font-bold text-lg">
-              🤖 AI Resume Conversion Prompt
-            </span>
-            <span className="text-xs bg-terminal-bright-green/30 px-2 py-1 rounded text-terminal-bright-green">
-              Ready to Copy
-            </span>
-          </div>
+        {/* Punched-through title — matches Block chrome */}
+        <div className="absolute -top-2.5 left-3 right-3 flex items-center justify-between font-mono text-xs pointer-events-none">
+          <span className="bg-terminal-black px-2 text-terminal-bright-green pointer-events-auto">
+            // ai-resume-prompt
+          </span>
           <button
             type="button"
             onClick={onClose}
             aria-label="Close"
-            className="text-terminal-bright-green hover:text-terminal-bright-green text-2xl font-bold w-8 h-8 flex items-center justify-center hover:bg-terminal-bright-green/20 rounded transition-all focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-terminal-bright-green"
+            className="bg-terminal-black px-2 text-tui-muted hover:text-terminal-bright-green pointer-events-auto focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-terminal-bright-green"
           >
-            ×
+            [esc]
           </button>
         </div>
 
-        <div className="flex-1 overflow-y-auto p-4 space-y-3">
-          <div className="text-terminal-green text-sm space-y-2">
-            <p>
-              <strong>How to use this prompt:</strong>
-            </p>
-            <ol className="list-decimal list-inside space-y-1 ml-2">
-              <li>Copy the prompt below using the button</li>
-              <li>Open ChatGPT, Claude, or Gemini</li>
-              <li>Paste the prompt</li>
-              <li>Attach or paste your existing resume (PDF, text, LinkedIn profile, etc.)</li>
+        <div className="flex-1 overflow-y-auto p-4 pt-5 space-y-3">
+          <div className="text-white/80 text-xs space-y-2">
+            <div className="text-tui-accent-dim">how to use:</div>
+            <ol className="list-decimal list-inside space-y-0.5 ml-2 text-xs">
+              <li>copy the prompt below</li>
+              <li>open ChatGPT / Claude / Gemini</li>
+              <li>paste the prompt</li>
+              <li>attach your existing resume (pdf, text, linkedin)</li>
               <li>
-                AI will generate perfect YAML — save it as{' '}
-                <code className="bg-black/50 px-1 rounded text-terminal-bright-green">
-                  resume.yaml
-                </code>
+                ai generates yaml — save as{' '}
+                <code className="text-terminal-bright-green">resume.yaml</code>
               </li>
             </ol>
           </div>
 
-          <div className="bg-black/50 rounded border border-terminal-bright-green/30 p-4 overflow-x-auto">
+          <div className="border border-tui-accent-dim/30 bg-terminal-black p-3 overflow-x-auto">
             {loadError ? (
-              <div className="text-terminal-red text-sm">{loadError}</div>
+              <div className="text-tui-error text-xs">{loadError}</div>
             ) : promptText ? (
-              <pre className="text-terminal-green text-xs leading-relaxed font-mono whitespace-pre-wrap">
+              <pre className="text-terminal-green text-[11px] sm:text-xs leading-relaxed font-mono whitespace-pre-wrap">
                 {promptText}
               </pre>
             ) : (
-              <div className="text-terminal-green/70 text-sm">Loading prompt…</div>
+              <div className="text-tui-muted text-xs">loading prompt…</div>
             )}
           </div>
         </div>
 
-        <div className="border-t border-terminal-bright-green/50 px-4 py-3 bg-terminal-bright-green/5 flex flex-col sm:flex-row gap-2 items-center justify-between">
-          <div className="text-xs text-terminal-bright-green/70">
-            {promptText ? `Prompt size: ${(promptText.length / 1024).toFixed(1)} KB` : ' '}
+        <div className="border-t border-tui-accent-dim/30 px-4 py-2 flex flex-col sm:flex-row gap-2 items-center justify-between">
+          <div className="text-[10px] text-tui-muted tabular-nums">
+            {promptText ? `size: ${(promptText.length / 1024).toFixed(1)} kb` : ' '}
           </div>
           <div className="flex gap-2">
             <button
               type="button"
               onClick={copyPrompt}
               disabled={!promptText}
-              className={`border px-4 py-2 rounded font-semibold transition-all duration-200 disabled:opacity-50 disabled:cursor-not-allowed focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-terminal-bright-green ${
+              className={`border px-3 py-1 text-xs font-mono transition-colors disabled:opacity-50 disabled:cursor-not-allowed focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-terminal-bright-green ${
                 copied
-                  ? 'bg-terminal-green/40 border-terminal-green text-terminal-bright-green shadow-[0_0_12px_rgba(var(--glow-color-rgb),0.4)] scale-[1.02]'
-                  : 'bg-terminal-bright-green/20 hover:bg-terminal-bright-green/30 border-terminal-bright-green/50 text-terminal-bright-green hover:scale-[1.02]'
+                  ? 'border-terminal-bright-green text-terminal-bright-green bg-terminal-bright-green/10'
+                  : 'border-terminal-bright-green/50 text-terminal-bright-green hover:bg-terminal-bright-green/10'
               }`}
             >
-              <span aria-hidden="true" className="inline-block mr-1 transition-transform duration-150">
-                {copied ? '✓' : '📋'}
-              </span>
-              {copied ? 'Copied!' : 'Copy Prompt'}
+              {copied ? '✓ copied' : 'copy prompt'}
             </button>
             <button
               type="button"
               onClick={onClose}
-              className="bg-terminal-red/20 hover:bg-terminal-red/30 border border-terminal-red/50 px-4 py-2 rounded text-terminal-red font-semibold transition-all focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-terminal-red"
+              className="border border-tui-muted/50 px-3 py-1 text-xs text-tui-muted font-mono hover:text-tui-error hover:border-tui-error/50 transition-colors focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-tui-error"
             >
-              Close
+              close
             </button>
           </div>
         </div>

--- a/client/src/components/tui/SectionBox.tsx
+++ b/client/src/components/tui/SectionBox.tsx
@@ -1,48 +1,56 @@
 import type { ReactNode } from 'react';
+import { Block } from './Block';
 
 interface SectionBoxProps {
-  /** Uppercase section title rendered in the header bar. */
+  /** Legacy title. Uppercase strings like "ABOUT ME" are normalised
+      to the GUI-matching `// about me` idiom automatically. Callers
+      that already prefix with `// ` are passed through untouched. */
   title: string;
-  /** Optional right-aligned slot — useful for a "Collapse All" button. */
+  /** Right-aligned control slot (typically a Collapse-All toggle).
+      Renders in `Block`'s `controls` position, next to the title. */
   right?: ReactNode;
-  /** Body content. */
   children: ReactNode;
-  /** Override the default `space-y-3` padding rhythm if the body has its
-      own internal layout (e.g., a collapsible list). */
   bodyClassName?: string;
-  /** Extra classes on the outer shell — rarely needed. */
   className?: string;
-  /** Centre the header text. A handful of commands (contact, help) use
-      a centred title in the legacy HTML templates. */
+  /** Accepted for source compatibility but ignored — the new
+      titled-border grammar always anchors the title to the top-left. */
   centerTitle?: boolean;
 }
 
 /**
- * The standard bordered box used by every command output. Header bar in
- * accent-bright-green, border/divider in accent at low opacity, inner
- * padding and vertical rhythm. Matches the visual language of the
- * existing HTML-string templates so JSX-migrated commands look identical.
+ * @deprecated
+ * Shim over {@link Block}. Every command used to build its chrome
+ * with this primitive; the migration to `Block` is mechanical because
+ * SectionBox now just re-renders as a Block with a normalised title.
+ *
+ * New code should import `Block` directly and pass a lowercase
+ * `// command` title — the normalisation here is a one-way migration
+ * helper, not something future components should rely on.
  */
 export function SectionBox({
   title,
   right,
   children,
-  bodyClassName = 'p-3 space-y-3 sm:space-y-4 text-xs sm:text-sm',
-  className = '',
-  centerTitle = false,
+  bodyClassName,
+  className,
+  centerTitle: _centerTitle,
 }: SectionBoxProps) {
-  const headerLayout = centerTitle
-    ? 'flex items-center justify-center text-center'
-    : 'flex items-center justify-between';
   return (
-    <div
-      className={`border border-terminal-green/50 rounded-sm mb-4 terminal-glow max-w-4xl ${className}`}
+    <Block
+      title={normaliseLegacyTitle(title)}
+      controls={right}
+      bodyClassName={bodyClassName}
+      className={className}
     >
-      <div className={`border-b border-terminal-green/30 px-3 py-1 ${headerLayout}`}>
-        <span className="text-terminal-bright-green text-sm font-bold">{title}</span>
-        {!centerTitle && right}
-      </div>
-      <div className={bodyClassName}>{children}</div>
-    </div>
+      {children}
+    </Block>
   );
+}
+
+/** Legacy "SECTION NAME" → "// section name". Preserves any title
+ *  that already matches the GUI idiom. */
+function normaliseLegacyTitle(raw: string): string {
+  if (raw.startsWith('//')) return raw;
+  const cleaned = raw.trim().toLowerCase();
+  return `// ${cleaned}`;
 }

--- a/client/src/components/tui/StatusBar.tsx
+++ b/client/src/components/tui/StatusBar.tsx
@@ -1,4 +1,18 @@
+import type { ReactNode } from 'react';
 import { Kbd } from './Kbd';
+import { ctrlKey, altKey, isTouchDevice } from '../../lib/platform';
+
+export interface StatusBarActions {
+  help: () => void;
+  search: () => void;
+  cmd: () => void;
+  recall: () => void;
+  palette: () => void;
+  cycleTheme: () => void;
+  toGui: () => void;
+  matrix: () => void;
+  clear: () => void;
+}
 
 interface StatusBarProps {
   /** Current theme display name (lowercase). */
@@ -10,21 +24,33 @@ interface StatusBarProps {
   /** Input mode — `insert` normally, `search` during reverse-search,
    *  `palette` when the command palette is open. */
   mode?: 'insert' | 'search' | 'palette';
+  /** Click/tap handlers for each chip — wired so the chips work as
+   *  buttons on touch devices (where modifier shortcuts don't exist)
+   *  and as tappable affordances on desktop too. */
+  actions: StatusBarActions;
+  /** When in `search` mode, supply current match position so the
+   *  status bar can show contextual hints in place of the chips. */
+  searchInfo?: {
+    matchIndex: number;
+    matchCount: number;
+  };
 }
 
 /**
- * Persistent footer strip — always visible. Two rows:
- *   - meta row (muted): mode · theme · blocks · history
- *   - hint row: key-chip hotkeys (lazygit / k9s / Ghostty idiom)
+ * Persistent footer strip — single row. Hints scroll-snap on the left,
+ * a compact meta cluster (mode · theme) right-aligned on wider screens.
  *
- * On narrow screens the meta row compresses to just mode+theme and
- * the hints scroll horizontally via snap-x so they're still reachable.
+ * Each chip is a real button — tapping fires the same action the
+ * keyboard shortcut would. Modifier symbols swap per OS (⌃/⌥ on Mac,
+ * Ctrl/Alt elsewhere). On touch devices the modifier-based chips are
+ * hidden (no Ctrl/Alt key on phones); the action is still reachable
+ * by typing the underlying command.
  */
 export function StatusBar({
   themeName,
-  blockCount,
-  historyCount,
   mode = 'insert',
+  actions,
+  searchInfo,
 }: StatusBarProps) {
   return (
     <footer
@@ -32,77 +58,88 @@ export function StatusBar({
       aria-label="terminal hints"
       className="flex-shrink-0 border-t border-tui-accent-dim/30 bg-terminal-black px-2 sm:px-3 py-1 font-mono text-[10px] sm:text-[11px] leading-tight"
     >
-      {/* Content width-capped to match Block / prompt so the footer
-          doesn't sprawl past the scrollback on wide monitors. The
-          border-t (above) still spans full viewport. */}
-      <div className="max-w-4xl">
-      {/* Meta row — muted stats */}
-      <div className="flex items-center gap-x-3 text-tui-muted mb-0.5 whitespace-nowrap overflow-x-auto scrollbar-hide">
-        <MetaSegment label="mode" value={mode} accent={mode !== 'insert'} />
-        <Sep />
-        <MetaSegment label="theme" value={themeName} />
-        <Sep className="hidden sm:inline" />
-        <MetaSegment label="blocks" value={String(blockCount)} className="hidden sm:inline-flex" />
-        <Sep className="hidden sm:inline" />
-        <MetaSegment label="history" value={String(historyCount)} className="hidden sm:inline-flex" />
-      </div>
-
-      {/* Hint row — key chips. All wired at window level so they work
-          even when focus is on a link or button. Alt+letter is used
-          for t/g/m so pressing those letters doesn't eat the first
-          char of a command. Non-letter keys (?, /, :) are safe as
-          bare since they never start a command word. */}
-      <div className="flex items-center gap-x-2 sm:gap-x-3 overflow-x-auto scrollbar-hide whitespace-nowrap">
-        <Hint chip="?" label="help" />
-        <Hint chip="/" label="search" />
-        <Hint chip=":" label="cmd" />
-        <Hint chip="⌃R" label="recall" />
-        <Hint chip="⌃K" label="palette" />
-        <Hint chip="o N" label="open link" />
-        <Hint chip="⌥T" label="theme" />
-        <Hint chip="⌥G" label="gui" />
-        <Hint chip="⌥M" label="matrix" />
-        <Hint chip="⌃L" label="clear" />
-      </div>
+      <div className="max-w-4xl flex items-center gap-x-3">
+        {mode === 'search' ? (
+          // Search-mode chips — replace the normal hint cluster so the
+          // reverse-search hints don't pop in as a third row above the
+          // status bar. Same row, same height, contextual contents.
+          <div className="flex items-center gap-x-2 sm:gap-x-3 overflow-x-auto scrollbar-hide whitespace-nowrap flex-1 min-w-0">
+            <span className="text-tui-accent-dim tabular-nums">
+              {searchInfo && searchInfo.matchCount > 0
+                ? `${searchInfo.matchIndex + 1}/${searchInfo.matchCount}`
+                : 'no match'}
+            </span>
+            <Hint chip={`${ctrlKey}R`} label="next" onTap={actions.recall} />
+            <Hint chip="↵" label="run" />
+            <Hint chip="tab" label="edit" />
+            <Hint chip="esc" label="cancel" />
+          </div>
+        ) : (
+          // Hint row — chips are buttons. Bare-key chips (?, /, :) work
+          // on every platform because the underlying keys exist on
+          // on-screen keyboards too. Modifier-based chips (⌃/⌥) hide
+          // on touch — a tap couldn't simulate a Ctrl-modified key
+          // event for the same handler, and the labels read as noise
+          // without a physical modifier key. The actions are still
+          // reachable by typing the underlying command (e.g. `theme`,
+          // `matrix`, `clear`).
+          <div className="flex items-center gap-x-2 sm:gap-x-3 overflow-x-auto scrollbar-hide whitespace-nowrap flex-1 min-w-0">
+            <Hint chip="?" label="help" onTap={actions.help} />
+            <Hint chip="/" label="search" onTap={actions.search} />
+            <Hint chip=":" label="cmd" onTap={actions.cmd} />
+            {!isTouchDevice && (
+              <>
+                <Hint chip={`${ctrlKey}R`} label="recall" onTap={actions.recall} />
+                <Hint chip={`${ctrlKey}K`} label="palette" onTap={actions.palette} />
+                <Hint chip={`${altKey}T`} label="theme" onTap={actions.cycleTheme} />
+                <Hint chip={`${altKey}G`} label="gui" onTap={actions.toGui} />
+                <Hint chip={`${altKey}M`} label="matrix" onTap={actions.matrix} />
+                <Hint chip={`${ctrlKey}L`} label="clear" onTap={actions.clear} />
+              </>
+            )}
+          </div>
+        )}
+        {/* Compact meta — only on wider screens. mode shows when not
+            insert (search/palette make it useful); theme is the soft
+            anchor for "what skin am I in". */}
+        <div className="hidden md:flex items-center gap-x-2 text-tui-muted whitespace-nowrap flex-shrink-0">
+          <span className={mode !== 'insert' ? 'text-terminal-bright-green' : 'text-tui-accent-dim'}>
+            {mode}
+          </span>
+          <span className="text-tui-muted/40" aria-hidden="true">·</span>
+          <span className="text-tui-accent-dim">{themeName}</span>
+        </div>
       </div>
     </footer>
   );
 }
 
-function MetaSegment({
+function Hint({
+  chip,
   label,
-  value,
-  accent = false,
-  className = '',
+  onTap,
 }: {
+  chip: ReactNode;
   label: string;
-  value: string;
-  accent?: boolean;
-  className?: string;
+  onTap?: () => void;
 }) {
-  return (
-    <span className={`inline-flex items-center gap-1 ${className}`}>
-      <span className="text-tui-muted/70">{label}:</span>
-      <span className={accent ? 'text-terminal-bright-green' : 'text-tui-accent-dim'}>
-        {value}
-      </span>
-    </span>
-  );
-}
-
-function Sep({ className = '' }: { className?: string }) {
-  return (
-    <span className={`text-tui-muted/40 ${className}`} aria-hidden="true">
-      ·
-    </span>
-  );
-}
-
-function Hint({ chip, label }: { chip: string; label: string }) {
-  return (
-    <span className="inline-flex items-center gap-1 text-tui-muted">
+  const inner = (
+    <>
       <Kbd>{chip}</Kbd>
       <span>{label}</span>
-    </span>
+    </>
   );
+  if (onTap) {
+    return (
+      <button
+        type="button"
+        onClick={onTap}
+        aria-label={label}
+        className="inline-flex items-center gap-1 text-tui-muted hover:text-terminal-bright-green focus-visible:outline-none focus-visible:text-terminal-bright-green transition-colors"
+      >
+        {inner}
+      </button>
+    );
+  }
+  return <span className="inline-flex items-center gap-1 text-tui-muted">{inner}</span>;
 }

--- a/client/src/components/tui/StatusBar.tsx
+++ b/client/src/components/tui/StatusBar.tsx
@@ -43,7 +43,11 @@ export function StatusBar({
         <MetaSegment label="history" value={String(historyCount)} className="hidden sm:inline-flex" />
       </div>
 
-      {/* Hint row — key chips */}
+      {/* Hint row — key chips. All wired at window level so they work
+          even when focus is on a link or button. Alt+letter is used
+          for t/g/m so pressing those letters doesn't eat the first
+          char of a command. Non-letter keys (?, /, :) are safe as
+          bare since they never start a command word. */}
       <div className="flex items-center gap-x-2 sm:gap-x-3 overflow-x-auto scrollbar-hide whitespace-nowrap">
         <Hint chip="?" label="help" />
         <Hint chip="/" label="search" />
@@ -51,8 +55,9 @@ export function StatusBar({
         <Hint chip="⌃R" label="recall" />
         <Hint chip="⌃K" label="palette" />
         <Hint chip="o N" label="open link" />
-        <Hint chip="t" label="theme" />
-        <Hint chip="g" label="gui" />
+        <Hint chip="⌥T" label="theme" />
+        <Hint chip="⌥G" label="gui" />
+        <Hint chip="⌥M" label="matrix" />
         <Hint chip="⌃L" label="clear" />
       </div>
     </footer>

--- a/client/src/components/tui/StatusBar.tsx
+++ b/client/src/components/tui/StatusBar.tsx
@@ -32,6 +32,10 @@ export function StatusBar({
       aria-label="terminal hints"
       className="flex-shrink-0 border-t border-tui-accent-dim/30 bg-terminal-black px-2 sm:px-3 py-1 font-mono text-[10px] sm:text-[11px] leading-tight"
     >
+      {/* Content width-capped to match Block / prompt so the footer
+          doesn't sprawl past the scrollback on wide monitors. The
+          border-t (above) still spans full viewport. */}
+      <div className="max-w-4xl">
       {/* Meta row — muted stats */}
       <div className="flex items-center gap-x-3 text-tui-muted mb-0.5 whitespace-nowrap overflow-x-auto scrollbar-hide">
         <MetaSegment label="mode" value={mode} accent={mode !== 'insert'} />
@@ -59,6 +63,7 @@ export function StatusBar({
         <Hint chip="⌥G" label="gui" />
         <Hint chip="⌥M" label="matrix" />
         <Hint chip="⌃L" label="clear" />
+      </div>
       </div>
     </footer>
   );

--- a/client/src/components/tui/StatusBar.tsx
+++ b/client/src/components/tui/StatusBar.tsx
@@ -1,0 +1,98 @@
+import { Kbd } from './Kbd';
+
+interface StatusBarProps {
+  /** Current theme display name (lowercase). */
+  themeName: string;
+  /** Count of output blocks in scrollback. */
+  blockCount: number;
+  /** Count of history entries. */
+  historyCount: number;
+  /** Input mode — `insert` normally, `search` during reverse-search,
+   *  `palette` when the command palette is open. */
+  mode?: 'insert' | 'search' | 'palette';
+}
+
+/**
+ * Persistent footer strip — always visible. Two rows:
+ *   - meta row (muted): mode · theme · blocks · history
+ *   - hint row: key-chip hotkeys (lazygit / k9s / Ghostty idiom)
+ *
+ * On narrow screens the meta row compresses to just mode+theme and
+ * the hints scroll horizontally via snap-x so they're still reachable.
+ */
+export function StatusBar({
+  themeName,
+  blockCount,
+  historyCount,
+  mode = 'insert',
+}: StatusBarProps) {
+  return (
+    <footer
+      role="toolbar"
+      aria-label="terminal hints"
+      className="flex-shrink-0 border-t border-tui-accent-dim/30 bg-terminal-black px-2 sm:px-3 py-1 font-mono text-[10px] sm:text-[11px] leading-tight"
+    >
+      {/* Meta row — muted stats */}
+      <div className="flex items-center gap-x-3 text-tui-muted mb-0.5 whitespace-nowrap overflow-x-auto scrollbar-hide">
+        <MetaSegment label="mode" value={mode} accent={mode !== 'insert'} />
+        <Sep />
+        <MetaSegment label="theme" value={themeName} />
+        <Sep className="hidden sm:inline" />
+        <MetaSegment label="blocks" value={String(blockCount)} className="hidden sm:inline-flex" />
+        <Sep className="hidden sm:inline" />
+        <MetaSegment label="history" value={String(historyCount)} className="hidden sm:inline-flex" />
+      </div>
+
+      {/* Hint row — key chips */}
+      <div className="flex items-center gap-x-2 sm:gap-x-3 overflow-x-auto scrollbar-hide whitespace-nowrap">
+        <Hint chip="?" label="help" />
+        <Hint chip="/" label="search" />
+        <Hint chip=":" label="cmd" />
+        <Hint chip="⌃R" label="recall" />
+        <Hint chip="⌃K" label="palette" />
+        <Hint chip="o N" label="open link" />
+        <Hint chip="t" label="theme" />
+        <Hint chip="g" label="gui" />
+        <Hint chip="⌃L" label="clear" />
+      </div>
+    </footer>
+  );
+}
+
+function MetaSegment({
+  label,
+  value,
+  accent = false,
+  className = '',
+}: {
+  label: string;
+  value: string;
+  accent?: boolean;
+  className?: string;
+}) {
+  return (
+    <span className={`inline-flex items-center gap-1 ${className}`}>
+      <span className="text-tui-muted/70">{label}:</span>
+      <span className={accent ? 'text-terminal-bright-green' : 'text-tui-accent-dim'}>
+        {value}
+      </span>
+    </span>
+  );
+}
+
+function Sep({ className = '' }: { className?: string }) {
+  return (
+    <span className={`text-tui-muted/40 ${className}`} aria-hidden="true">
+      ·
+    </span>
+  );
+}
+
+function Hint({ chip, label }: { chip: string; label: string }) {
+  return (
+    <span className="inline-flex items-center gap-1 text-tui-muted">
+      <Kbd>{chip}</Kbd>
+      <span>{label}</span>
+    </span>
+  );
+}

--- a/client/src/components/tui/TuiLink.tsx
+++ b/client/src/components/tui/TuiLink.tsx
@@ -57,6 +57,7 @@ export function ExtLink({ href, children, className = '', silent = false }: ExtL
       href={href}
       target="_blank"
       rel="noopener noreferrer"
+      aria-label={n !== null ? `${label} (link ${n})` : undefined}
       className={`text-terminal-bright-green underline hover:opacity-80 rounded-sm focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-terminal-bright-green ${className}`}
     >
       {children}

--- a/client/src/components/tui/TuiLink.tsx
+++ b/client/src/components/tui/TuiLink.tsx
@@ -1,4 +1,5 @@
-import type { ReactNode } from 'react';
+import { useMemo, type ReactNode } from 'react';
+import { useTerminalLinks } from './LinkRegistry';
 
 interface CmdLinkProps {
   /** Target command name, e.g. "skills". Rendered as `?cmd=skills` so
@@ -30,14 +31,27 @@ interface ExtLinkProps {
   href: string;
   children: ReactNode;
   className?: string;
+  /** Hide the `[N]` number tag. Default `false` — tags are visible
+      so users discover the `o N` / `g N` open-by-number shortcut.
+      Set `silent` for very short inline links that would disturb
+      prose flow. */
+  silent?: boolean;
 }
 
 /**
  * External http/https link. Opens in a new tab with `noopener
- * noreferrer`. Accent-underlined so it's clearly clickable in a block
- * of plain terminal text.
+ * noreferrer`. Accent-underlined, with a `[N]` tag that resolves via
+ * the terminal's link registry so `o N` / `g N` opens it keyboard-
+ * only.
  */
-export function ExtLink({ href, children, className = '' }: ExtLinkProps) {
+export function ExtLink({ href, children, className = '', silent = false }: ExtLinkProps) {
+  const registry = useTerminalLinks();
+  const label = typeof children === 'string' ? children : href;
+  const n = useMemo(
+    () => (registry ? registry.register(href, label) : null),
+    [registry, href, label],
+  );
+
   return (
     <a
       href={href}
@@ -46,6 +60,14 @@ export function ExtLink({ href, children, className = '' }: ExtLinkProps) {
       className={`text-terminal-bright-green underline hover:opacity-80 rounded-sm focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-terminal-bright-green ${className}`}
     >
       {children}
+      {n !== null && !silent && (
+        <span
+          aria-hidden="true"
+          className="ml-1 text-tui-muted text-[10px] sm:text-xs tabular-nums"
+        >
+          [{n}]
+        </span>
+      )}
     </a>
   );
 }

--- a/client/src/components/tui/TuiLink.tsx
+++ b/client/src/components/tui/TuiLink.tsx
@@ -31,23 +31,22 @@ interface ExtLinkProps {
   href: string;
   children: ReactNode;
   className?: string;
-  /** Hide the `[N]` number tag. Default `false` — tags are visible
-      so users discover the `o N` / `g N` open-by-number shortcut.
-      Set `silent` for very short inline links that would disturb
-      prose flow. */
+  /** Legacy prop — used to hide the inline `[N]` tag. The tag has
+      since been removed entirely; this is kept as a no-op so existing
+      call sites compile. */
   silent?: boolean;
 }
 
 /**
  * External http/https link. Opens in a new tab with `noopener
- * noreferrer`. Accent-underlined, with a `[N]` tag that resolves via
- * the terminal's link registry so `o N` / `g N` opens it keyboard-
- * only.
+ * noreferrer`. Still registers with the terminal-wide registry so the
+ * `open N` command resolves it; the visible `[N]` suffix has been
+ * removed to keep outputs uncluttered.
  */
-export function ExtLink({ href, children, className = '', silent = false }: ExtLinkProps) {
+export function ExtLink({ href, children, className = '' }: ExtLinkProps) {
   const registry = useTerminalLinks();
   const label = typeof children === 'string' ? children : href;
-  const n = useMemo(
+  useMemo(
     () => (registry ? registry.register(href, label) : null),
     [registry, href, label],
   );
@@ -57,18 +56,9 @@ export function ExtLink({ href, children, className = '', silent = false }: ExtL
       href={href}
       target="_blank"
       rel="noopener noreferrer"
-      aria-label={n !== null ? `${label} (link ${n})` : undefined}
       className={`text-terminal-bright-green underline hover:opacity-80 rounded-sm focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-terminal-bright-green ${className}`}
     >
       {children}
-      {n !== null && !silent && (
-        <span
-          aria-hidden="true"
-          className="ml-1 text-tui-muted text-[10px] sm:text-xs tabular-nums"
-        >
-          [{n}]
-        </span>
-      )}
     </a>
   );
 }

--- a/client/src/config/gui-theme.config.ts
+++ b/client/src/config/gui-theme.config.ts
@@ -87,7 +87,11 @@ export function applyColorTheme(theme: ColorTheme) {
   const dimSat = Math.max(40, sat - 20);
   const dimLight = Math.max(25, light - 20);
   root.setProperty('--tui-accent-dim', hsl(hue, dimSat, dimLight));
-  root.setProperty('--tui-muted', hsl(hue, Math.max(10, sat - 70), 60));
+  // Muted uses a very low saturation cap (max 12%) so warm hues
+  // (amber/yellow) don't land in olive-tan territory and read as
+  // "greenish" on a dark background. Low-chroma gray with a whisper
+  // of the accent hue reads as neutral warm/cool gray across themes.
+  root.setProperty('--tui-muted', hsl(hue, Math.min(12, sat / 6), 60));
   root.setProperty('--tui-error', 'hsl(0, 100%, 60%)');
   root.setProperty('--tui-warn', 'hsl(45, 100%, 55%)');
 

--- a/client/src/config/gui-theme.config.ts
+++ b/client/src/config/gui-theme.config.ts
@@ -79,6 +79,18 @@ export function applyColorTheme(theme: ColorTheme) {
   root.setProperty('--input', hsl(hue, sat, 20));
   root.setProperty('--glow-color-rgb', `${r}, ${g}, ${b}`);
 
+  // TUI semantic tokens — theme-following. Before this, `--terminal-yellow`
+  // and the scanline tint were hardcoded and ignored every theme, so a
+  // Glacier user saw lemon labels. Now labels derive from the accent hue
+  // at a darker lightness, giving mono-accent discipline across themes.
+  // Errors stay hardcoded red — they must pop regardless of theme.
+  const dimSat = Math.max(40, sat - 20);
+  const dimLight = Math.max(25, light - 20);
+  root.setProperty('--tui-accent-dim', hsl(hue, dimSat, dimLight));
+  root.setProperty('--tui-muted', hsl(hue, Math.max(10, sat - 70), 60));
+  root.setProperty('--tui-error', 'hsl(0, 100%, 60%)');
+  root.setProperty('--tui-warn', 'hsl(45, 100%, 55%)');
+
   // Sync both localStorage keys so terminal and GUI stay in sync
   localStorage.setItem('gui-color-theme', theme.key);
   localStorage.setItem('terminal-theme', theme.key);

--- a/client/src/config/gui-theme.config.ts
+++ b/client/src/config/gui-theme.config.ts
@@ -84,8 +84,14 @@ export function applyColorTheme(theme: ColorTheme) {
   // Glacier user saw lemon labels. Now labels derive from the accent hue
   // at a darker lightness, giving mono-accent discipline across themes.
   // Errors stay hardcoded red — they must pop regardless of theme.
-  const dimSat = Math.max(40, sat - 20);
-  const dimLight = Math.max(25, light - 20);
+  //
+  // accent-dim must remain readable on a black background. dim at L=30
+  // worked for matrix/yellow/red (warm hues stay readable when dark)
+  // but landed too muddy for cooler hues (blue/cyan/glacier — dark
+  // teal on black is hard to scan). Bump to L=42 for a consistent
+  // mid-tone that reads across all hues.
+  const dimSat = Math.max(50, sat - 10);
+  const dimLight = Math.max(38, light - 10);
   root.setProperty('--tui-accent-dim', hsl(hue, dimSat, dimLight));
   // Muted uses a very low saturation cap (max 12%) so warm hues
   // (amber/yellow) don't land in olive-tan territory and read as

--- a/client/src/config/index.ts
+++ b/client/src/config/index.ts
@@ -12,3 +12,4 @@ export { socialConfig, getSocialNetworkUrl } from './social.config';
 export { storageConfig, storage } from './storage.config';
 export { guiTheme, accentHex, accentHoverHex, accentRgbStr, accentRgba, accentRgbCss, getAccentRgb, colorThemes, applyColorTheme, getSavedTheme, cycleTheme } from './gui-theme.config';
 export type { ColorTheme } from './gui-theme.config';
+export { tuiVars, tuiColor, tuiRhythm, tuiText, tuiChrome, tuiClass } from './tui-tokens';

--- a/client/src/config/index.ts
+++ b/client/src/config/index.ts
@@ -5,7 +5,7 @@
  * Import configs using: import { terminalConfig, uiText, apiConfig, socialConfig, storageConfig, storage } from '@/config';
  */
 
-export { terminalConfig, getPromptString } from './terminal.config';
+export { terminalConfig, getPromptString, derivePromptUser, formatPrompt } from './terminal.config';
 export { uiText, formatMessage } from './ui.config';
 export { apiConfig, getEndpointUrl, fetchWithTimeout } from './api.config';
 export { socialConfig, getSocialNetworkUrl } from './social.config';

--- a/client/src/config/terminal.config.ts
+++ b/client/src/config/terminal.config.ts
@@ -7,7 +7,11 @@
 
 export const terminalConfig = {
   /**
-   * Terminal prompt configuration
+   * Terminal prompt configuration. The username and directory are
+   * dynamic in practice — username is derived from portfolio cv.name
+   * at runtime (see `derivePromptUser`), and directory changes with
+   * each navigation command (see `usePromptContext` in useTerminal).
+   * These values are the fallback defaults used before data loads.
    */
   prompt: {
     username: 'guest',
@@ -34,10 +38,38 @@ export const terminalConfig = {
 } as const;
 
 /**
- * Generate the full terminal prompt string
+ * Generate the full terminal prompt string (legacy, fixed).
  * Format: username@hostname:directory$
+ *
+ * @deprecated Use `formatPrompt` + the dynamic context from
+ *   useTerminal for Starship-style contextual prompts. Kept only as a
+ *   fallback for callers not yet on the new plumbing.
  */
 export function getPromptString(): string {
   const { username, hostname, directory, symbol } = terminalConfig.prompt;
   return `${username}@${hostname}:${directory}${symbol}`;
+}
+
+/** Derive the prompt user from a portfolio CV name — lowercase, no
+ *  spaces. Falls back to the configured default if name is empty. */
+export function derivePromptUser(name: string | undefined | null): string {
+  if (!name) return terminalConfig.prompt.username;
+  const slug = name.toLowerCase().split(/\s+/)[0];
+  return slug || terminalConfig.prompt.username;
+}
+
+/** Starship-style assembled prompt string (no colors — plain text,
+ *  used for echo'd command lines in the scrollback). The live input
+ *  prompt uses colored spans; see `Terminal.tsx`. */
+export function formatPrompt(opts: {
+  user?: string;
+  host?: string;
+  dir?: string;
+  symbol?: string;
+}): string {
+  const user = opts.user ?? terminalConfig.prompt.username;
+  const host = opts.host ?? terminalConfig.prompt.hostname;
+  const dir = opts.dir ?? terminalConfig.prompt.directory;
+  const symbol = opts.symbol ?? terminalConfig.prompt.symbol;
+  return `${user}@${host} ${dir} ${symbol}`;
 }

--- a/client/src/config/tui-tokens.ts
+++ b/client/src/config/tui-tokens.ts
@@ -1,0 +1,88 @@
+/**
+ * TUI Design Tokens
+ *
+ * Single source of truth for TUI colors, spacing, and effects. All
+ * colors are CSS variable names — `applyColorTheme()` rewrites them
+ * live on theme change so the TUI and GUI stay hue-synced without a
+ * reload.
+ *
+ * Design stance:
+ *   - One accent (plus its dim/bright/faint derivatives) — matches
+ *     the GUI's mono-accent discipline.
+ *   - Error is hardcoded red across themes; errors must always pop.
+ *   - Sharp corners (radius: 0) — matches the GUI's brutalist shape
+ *     language. No `rounded-lg` except in very specific affordances.
+ */
+
+/** CSS variables written by `applyColorTheme()`. Read with `var(...)`. */
+export const tuiVars = {
+  accent: '--terminal-green',
+  accentBright: '--terminal-bright-green',
+  accentDim: '--tui-accent-dim',
+  accentRgb: '--glow-color-rgb',
+  muted: '--tui-muted',
+  error: '--tui-error',
+  warn: '--tui-warn',
+} as const;
+
+/** Semantic color tokens — pass these into `style={{ color: ... }}`. */
+export const tuiColor = {
+  accent: `var(${tuiVars.accent})`,
+  accentBright: `var(${tuiVars.accentBright})`,
+  accentDim: `var(${tuiVars.accentDim})`,
+  accentFaint: `rgba(var(${tuiVars.accentRgb}), 0.3)`,
+  accentWash: `rgba(var(${tuiVars.accentRgb}), 0.05)`,
+  muted: `var(${tuiVars.muted})`,
+  error: `var(${tuiVars.error})`,
+  warn: `var(${tuiVars.warn})`,
+  text: '#ffffff',
+  textDim: 'rgba(255, 255, 255, 0.7)',
+  bg: 'var(--terminal-black)',
+} as const;
+
+/** Vertical rhythm. Use as Tailwind utility classes. */
+export const tuiRhythm = {
+  tight: 'space-y-1',
+  base: 'space-y-3',
+  loose: 'space-y-5',
+} as const;
+
+/** Typography scale. Chrome uses a fixed smaller size; body uses the
+ *  base/sm responsive pair so lines wrap the same way on mobile. */
+export const tuiText = {
+  body: 'text-sm sm:text-base',
+  label: 'text-xs sm:text-sm',
+  chrome: 'text-xs',
+} as const;
+
+/** Chrome primitives — widths and shadows used by `Block`. */
+export const tuiChrome = {
+  rail: '2px',
+  borderColor: `rgba(var(${tuiVars.accentRgb}), 0.3)`,
+  glow: `0 0 12px rgba(var(${tuiVars.accentRgb}), 0.15)`,
+  radius: '0',
+} as const;
+
+/** Tailwind class map — usable as bg / text / border utilities. */
+export const tuiClass = {
+  text: {
+    accent: 'text-terminal-green',
+    accentBright: 'text-terminal-bright-green',
+    accentDim: 'text-tui-accent-dim',
+    muted: 'text-tui-muted',
+    error: 'text-tui-error',
+    warn: 'text-tui-warn',
+  },
+  bg: {
+    accent: 'bg-terminal-green',
+    accentWash: 'bg-terminal-green/5',
+    accentFaint: 'bg-terminal-green/10',
+    bg: 'bg-terminal-black',
+  },
+  border: {
+    accent: 'border-terminal-green',
+    accentFaint: 'border-terminal-green/30',
+    accentDim: 'border-tui-accent-dim/50',
+    error: 'border-tui-error/50',
+  },
+} as const;

--- a/client/src/config/ui.config.ts
+++ b/client/src/config/ui.config.ts
@@ -27,7 +27,6 @@ export const uiText = {
    * Welcome banner and greeting
    */
   welcome: {
-    greeting: 'a portfolio that talks back. type `help` or pick a tile.',
     /** Legacy — unused since Phase 2 swapped welcome to Block chrome. */
     title: '',
   },

--- a/client/src/config/ui.config.ts
+++ b/client/src/config/ui.config.ts
@@ -1,8 +1,17 @@
 /**
  * UI Text Configuration
  *
- * Centralizes all user-facing text, messages, and labels used throughout
- * the terminal interface.
+ * Centralizes all user-facing text used throughout the terminal.
+ *
+ * Voice guide:
+ *   - Lowercase section titles: `// about`, `// experience`, `// projects`.
+ *   - Em-dash (—) not hyphen: "Jan 2021 — Present".
+ *   - Terse. No marketing. No "🚀". Emoji reserved for:
+ *       - boot sequence
+ *       - `konami` easter-egg reveal
+ *       - `coffee` easter egg
+ *   - Errors are Unix-literal: `bash: foo: command not found`.
+ *   - Help tips are one-line, never promotional.
  */
 
 export const uiText = {
@@ -10,31 +19,34 @@ export const uiText = {
    * Terminal loading and initialization messages
    */
   loading: {
-    text: 'Initializing terminal...',
-    error: 'Failed to load portfolio data',
+    text: 'initializing terminal…',
+    error: 'failed to load portfolio data',
   },
 
   /**
    * Welcome banner and greeting
    */
   welcome: {
-    greeting: 'Welcome to my portfolio!',
-    title: 'TERMINAL PORTFOLIO',
+    greeting: 'a portfolio that talks back. type `help` or pick a tile.',
+    /** Legacy — unused since Phase 2 swapped welcome to Block chrome. */
+    title: '',
   },
 
   /**
-   * Section headers
+   * Section headers — legacy uppercase values. All commands have been
+   * migrated to pass `// lowercase` titles directly; these are kept
+   * for backwards compat with any caller that still reads them.
    */
   sections: {
-    help: { title: 'AVAILABLE COMMANDS' },
-    about: { title: 'ABOUT ME' },
-    skills: { title: 'TECHNOLOGIES & SKILLS' },
-    experience: { title: 'WORK EXPERIENCE' },
-    education: { title: 'EDUCATION' },
-    projects: { title: 'PROJECTS' },
-    professionalProjects: { title: 'PROFESSIONAL PROJECTS' },
-    personalProjects: { title: 'PERSONAL PROJECTS' },
-    publications: { title: 'PUBLICATIONS' },
+    help: { title: '// help' },
+    about: { title: '// about' },
+    skills: { title: '// skills' },
+    experience: { title: '// experience' },
+    education: { title: '// education' },
+    projects: { title: '// projects' },
+    professionalProjects: { title: '// projects' },
+    personalProjects: { title: '// personal' },
+    publications: { title: '// publications' },
   },
 
   /**
@@ -43,20 +55,20 @@ export const uiText = {
   messages: {
     error: {
       commandNotFound: 'bash: {cmd}: command not found',
-      invalidArgument: 'Invalid argument: {arg}',
-      noData: 'No data available',
-      portfolioNotLoaded: 'Portfolio data not loaded',
-      resumeNotFound: 'Resume URL not found',
-      noPublications: 'No publications found',
-      noProfessionalProjects: 'No professional projects found',
-      noPersonalProjects: 'No personal projects found',
-      loadFailed: 'Error loading neofetch content!',
+      invalidArgument: 'invalid argument: {arg}',
+      noData: 'no data available',
+      portfolioNotLoaded: 'portfolio data not loaded',
+      resumeNotFound: 'resume url not found',
+      noPublications: 'no publications found',
+      noProfessionalProjects: 'no professional projects found',
+      noPersonalProjects: 'no personal projects found',
+      loadFailed: 'error loading neofetch content',
     },
     info: {
-      typeHelp: "Type 'help' to see available commands",
-      cleared: 'Terminal cleared',
-      opening: 'Opening {target}...',
-      connecting: "💡 LET'S CONNECT",
+      typeHelp: "type 'help' to see available commands",
+      cleared: 'terminal cleared',
+      opening: 'opening {target}…',
+      connecting: "// let's connect",
     },
   },
 
@@ -70,20 +82,21 @@ export const uiText = {
   },
 
   /**
-   * Timeline section headers
+   * Timeline section headers — lowercase to match the GUI idiom.
+   * Rendered as `work`, `research`, etc. inside the timeline block.
    */
   timeline: {
-    education: 'EDUCATION',
-    work: 'WORK',
-    project: 'PROJECT',
-    research: 'RESEARCH',
+    education: 'education',
+    work: 'work',
+    project: 'project',
+    research: 'research',
   },
 
   /**
    * Input placeholder text
    */
   input: {
-    placeholder: 'Type a command...',
+    placeholder: 'type a command…',
   },
 } as const;
 

--- a/client/src/hooks/useTerminal.tsx
+++ b/client/src/hooks/useTerminal.tsx
@@ -3,7 +3,7 @@ import { type PortfolioData } from '../../../shared/schema';
 import { formatExperiencePeriod, getSocialNetworkUrl } from '../lib/portfolioData';
 import { themes } from '../lib/themes';
 import { colorThemes, applyColorTheme } from '../config/gui-theme.config';
-import { uiText, formatMessage, apiConfig, terminalConfig, storage, storageConfig } from '../config';
+import { uiText, formatMessage, apiConfig, terminalConfig, derivePromptUser, storage, storageConfig } from '../config';
 import { renderCustomFields } from '../lib/fieldRenderer';
 import { inlineMd } from '../lib/tuiMarkdown';
 import { Block } from '../components/tui/Block';
@@ -394,6 +394,13 @@ export function useTerminal({ portfolioData, onSwitchToGUI }: UseTerminalProps) 
   const [historyIndex, setHistoryIndex] = useState(-1);
   const [currentInput, setCurrentInput] = useState('');
   const [isTyping, setIsTyping] = useState(false);
+  /** Current pseudo-directory — Starship-style prompt context. Reset
+   *  on `clear`; advanced by destination commands (about → ~/about).
+   *  Non-destination commands (theme, ls, history, search) leave it. */
+  const [currentDir, setCurrentDir] = useState('~');
+  /** Exit code of the most recent command. 0 = success, 127 = not
+   *  found, 1 = handler failed, null = no commands run yet. */
+  const [lastExitCode, setLastExitCode] = useState<number | null>(null);
   const lineIdCounter = useRef(0);
 
   const generateId = () => `line-${++lineIdCounter.current}`;
@@ -428,7 +435,18 @@ export function useTerminal({ portfolioData, onSwitchToGUI }: UseTerminalProps) 
 
   const clearTerminal = useCallback(() => {
     setLines([]);
+    setCurrentDir('~');
   }, []);
+
+  /** Commands that represent a "navigation" — they change the prompt
+   *  context to `~/<cmd>`. Utility commands (ls, pwd, history, theme,
+   *  search, clear, gui, resume, help) don't move the user anywhere.
+   *  `welcome` resets to `~/` since that's the landing state. */
+  const DESTINATION_COMMANDS = new Set([
+    'about', 'skills', 'experience', 'education', 'projects',
+    'personal', 'publications', 'timeline', 'contact', 'whoami',
+    'neofetch', 'replicate', 'clone', 'fork', 'stats',
+  ]);
 
   // Get available commands based on portfolio data
   const getAvailableCommands = useCallback((): CommandMetadata[] => {
@@ -2125,8 +2143,11 @@ export function useTerminal({ portfolioData, onSwitchToGUI }: UseTerminalProps) 
 
   const executeCommand = useCallback((command: string) => {
     if (!command.trim()) return;
-    
-    addLine(`guest@portfolio:~$ ${command}`, 'text-terminal-green font-semibold', true);
+
+    // Derive user slug from cv.name so the echoed line matches the
+    // live prompt. Falls back to 'guest' if data isn't loaded yet.
+    const user = derivePromptUser(portfolioData?.cv.name);
+    addLine(`${user}@portfolio ${currentDir} $ ${command}`, 'text-terminal-green font-semibold', true);
     setCommandHistory(prev => {
       // Collapse duplicates at the top so spamming the same command doesn't
       // fill history. Cap at `maxHistoryItems` from storage config.
@@ -2134,7 +2155,7 @@ export function useTerminal({ portfolioData, onSwitchToGUI }: UseTerminalProps) 
       return deduped.slice(0, storageConfig.limits.maxHistoryItems);
     });
     setHistoryIndex(-1);
-    
+
     const args = command.trim().split(' ');
     const cmd = args[0].toLowerCase();
 
@@ -2147,14 +2168,29 @@ export function useTerminal({ portfolioData, onSwitchToGUI }: UseTerminalProps) 
       );
 
       if (commandInRegistry && commandInRegistry.isAvailable && !commandInRegistry.isAvailable(portfolioData)) {
-        addLine(`Command '${cmd}' is not available (no data found)`, 'text-terminal-yellow');
+        addLine(`command '${cmd}' is not available (no data found)`, 'text-tui-accent-dim');
+        setLastExitCode(1);
         return;
       }
 
       // Command doesn't exist at all
-      addLine(formatMessage(uiText.messages.error.commandNotFound, { cmd }), 'text-terminal-red');
+      addLine(formatMessage(uiText.messages.error.commandNotFound, { cmd }), 'text-tui-error');
+      setLastExitCode(127);
       return;
     }
+
+    // Navigation commands move the prompt dir; utility commands don't.
+    if (DESTINATION_COMMANDS.has(cmd)) {
+      // Normalise aliases to their canonical dir (clone/fork → replicate).
+      const canonical = cmd === 'clone' || cmd === 'fork' ? 'replicate' : cmd;
+      setCurrentDir(`~/${canonical}`);
+    } else if (cmd === 'welcome') {
+      setCurrentDir('~');
+    } else if (cmd === 'cat' && args[1] === 'resume.txt') {
+      setCurrentDir('~/docs');
+    }
+    // Success by default; specific commands override below if they fail.
+    setLastExitCode(0);
 
     switch (cmd) {
       case 'help':
@@ -2206,7 +2242,8 @@ export function useTerminal({ portfolioData, onSwitchToGUI }: UseTerminalProps) 
         listCommands();
         break;
       case 'pwd':
-        addLine('/home/user/portfolio', 'text-white');
+        // Mirror Unix: strip leading `~` and render as an absolute path.
+        addLine(`/home/${user}/portfolio${currentDir.replace(/^~/, '')}`, 'text-white');
         break;
       case 'cat':
         showCat(args.slice(1));
@@ -2252,7 +2289,7 @@ export function useTerminal({ portfolioData, onSwitchToGUI }: UseTerminalProps) 
           </span>,
         );
     }
-  }, [addLine, addNode, showHelp, openResumePdf, showWelcomeMessage, showAbout, showSkills, showExperience, showEducation, showProjects, showPersonalProjects, showContact, showPublications, showTimeline, showSearch, showTheme, showWhoAmI, listCommands, showCat, showNeofetch, showReplicate, showHistory, clearTerminal, showGenericSection, portfolioData, onSwitchToGUI]);
+  }, [addLine, addNode, showHelp, openResumePdf, showWelcomeMessage, showAbout, showSkills, showExperience, showEducation, showProjects, showPersonalProjects, showContact, showPublications, showTimeline, showSearch, showTheme, showWhoAmI, listCommands, showCat, showNeofetch, showReplicate, showHistory, clearTerminal, showGenericSection, portfolioData, onSwitchToGUI, currentDir]);
 
   const navigateHistory = useCallback((direction: 'up' | 'down') => {
     if (commandHistory.length === 0) return currentInput;
@@ -2290,6 +2327,9 @@ export function useTerminal({ portfolioData, onSwitchToGUI }: UseTerminalProps) 
     return getAllCommandNames();
   }, [getAllCommandNames]);
 
+  // Username slug for prompt display — derived from cv.name once loaded.
+  const promptUser = derivePromptUser(portfolioData?.cv.name);
+
   return {
     lines,
     executeCommand,
@@ -2306,5 +2346,10 @@ export function useTerminal({ portfolioData, onSwitchToGUI }: UseTerminalProps) 
     setCurrentInput,
     clearTerminal,
     showWelcomeMessage,
+    // Starship-style prompt context.
+    currentDir,
+    lastExitCode,
+    promptUser,
+    promptHost: terminalConfig.prompt.hostname,
   };
 }

--- a/client/src/hooks/useTerminal.tsx
+++ b/client/src/hooks/useTerminal.tsx
@@ -2036,7 +2036,7 @@ export function useTerminal({ portfolioData, onSwitchToGUI }: UseTerminalProps) 
         )}
         <div>└{border}┘</div>
         <div>{'\u00A0'}</div>
-        <div className="text-terminal-dim">
+        <div className="text-tui-muted">
           💡 Tip: Create a custom banner by adding client/public/data/neofetch.txt
         </div>
         <div>{'\u00A0'}</div>

--- a/client/src/hooks/useTerminal.tsx
+++ b/client/src/hooks/useTerminal.tsx
@@ -443,6 +443,7 @@ const COMMAND_REGISTRY: CommandMetadata[] = [
   { name: 'sudo', description: 'A pleasant refusal', category: 'hidden', hidden: true, argsHint: '<anything>' },
   { name: 'matrix', description: 'Trigger the idle screensaver on demand', category: 'hidden', hidden: true },
   { name: 'konami', description: 'Cycle color theme with a flash', category: 'hidden', hidden: true },
+  { name: 'rm', description: 'Tread carefully', category: 'hidden', hidden: true, argsHint: '-rf /' },
   // `o N` / `g N` — vim-motion link open. The handler reads the
   // argument number and opens the corresponding registered link.
   { name: 'open', description: 'Open link by number', category: 'tools', hidden: true, aliases: ['o', 'g'], argsHint: '<N>' },
@@ -2279,14 +2280,106 @@ export function useTerminal({ portfolioData, onSwitchToGUI, onTriggerMatrix }: U
     );
   }, [addNode]);
 
+  const showRmRf = useCallback(async () => {
+    // Theatrical `rm -rf /` — hybrid of Permission-denied wall + rapid
+    // fake deletions + recovery wink. Two acts:
+    //
+    //   Act 1 (D): Unix-faithful "Permission denied" wall. System looks
+    //              resistant. User expects the joke to end here.
+    //   Act 2 (A): transition shows privilege "escalation", then a
+    //              cascade of fake deletions. Climax wipes the screen.
+    //              Recovery line restores context with a dry joke.
+    //
+    // The whole theater takes ~3.2s — short enough that users watch it
+    // rather than type through it.
+    const delay = (ms: number) => new Promise<void>((r) => setTimeout(r, ms));
+    // The default scroll-anchor pins the command at the top of the
+    // viewport, which means the theater cascade flows off-screen. For
+    // this show specifically, override by scrolling the pane to the
+    // bottom after each beat.
+    const stickBottom = () => {
+      const pane = document.querySelector<HTMLElement>('[role="log"]');
+      if (pane) pane.scrollTop = pane.scrollHeight;
+    };
+    const beat = (text: string, cls: string) => {
+      addLine(text, cls);
+      // Defer to the next paint so the scrollHeight includes the line.
+      requestAnimationFrame(stickBottom);
+    };
+
+    // --- Act 1: permission denied --------------------------------------
+    const protectedPaths = [
+      '/boot/grub',
+      '/etc/shadow',
+      '/usr/bin',
+      '/var/log/syslog',
+      '/sys/kernel',
+      '/dev/sda',
+      '/root',
+      '/home/subhayu',
+    ];
+    for (const p of protectedPaths) {
+      beat(`rm: cannot remove '${p}': Permission denied`, 'text-tui-error');
+      await delay(55);
+    }
+    await delay(350);
+
+    // --- Transition: escalate ------------------------------------------
+    beat('escalating privileges…', 'text-tui-warn');
+    await delay(650);
+    beat('[sudo] password for visitor: ········', 'text-tui-muted');
+    await delay(250);
+    beat(
+      'authentication bypass: portfolio_mode=true',
+      'text-terminal-bright-green',
+    );
+    await delay(450);
+
+    // --- Act 2: rapid fake deletions -----------------------------------
+    const condemned = [
+      '/bin', '/etc', '/lib', '/lib64', '/opt', '/proc', '/root',
+      '/sbin', '/sys', '/tmp', '/usr', '/var',
+      '/home/subhayu/.ssh',
+      '/home/subhayu/.bash_history',
+      '/home/subhayu/portfolio',
+      '/home/subhayu/portfolio/about',
+      '/home/subhayu/portfolio/experience',
+      '/home/subhayu/portfolio/projects',
+      '/home/subhayu/portfolio/skills',
+      '/home/subhayu',
+      '/',
+    ];
+    for (const p of condemned) {
+      beat(`removing ${p}`, 'text-tui-error');
+      await delay(30);
+    }
+    await delay(250);
+    beat('!!! filesystem vanished !!!', 'text-terminal-bright-green');
+    await delay(800);
+
+    // --- Recovery ------------------------------------------------------
+    clearTerminal();
+    addLine('// restored from backup (3.2s). nothing actually broke.', 'text-terminal-bright-green');
+    addLine(
+      "// turns out you can't delete a read-only portfolio. try `help`.",
+      'text-tui-accent-dim',
+    );
+  }, [addLine, clearTerminal]);
+
   const showSudo = useCallback((args: string[]) => {
     const sub = args.join(' ').trim();
     if (!sub) {
       addLine('usage: sudo <command>', 'text-tui-muted');
       return;
     }
-    if (/rm\s+-r?f?\s*\/?/i.test(sub)) {
-      addLine('nice try. this is a portfolio, not your filesystem.', 'text-tui-accent-dim');
+    if (/^rm\s+-r?f?\s*\/?/i.test(sub)) {
+      // Route the classic meme through the actual `rm -rf /` theater —
+      // `sudo rm -rf /` gets a brief wink before the show starts.
+      addLine(
+        'sudo: privilege escalation acknowledged. unleashing…',
+        'text-tui-warn',
+      );
+      setTimeout(() => void showRmRf(), 250);
       return;
     }
     if (/shutdown|reboot|halt/i.test(sub)) {
@@ -2580,6 +2673,22 @@ export function useTerminal({ portfolioData, onSwitchToGUI, onTriggerMatrix }: U
       case 'konami':
         showKonami();
         break;
+      case 'rm': {
+        // The infamous command. Unix-faithful for anything that
+        // isn't `-rf /`; full theater for the classic.
+        const tail = args.slice(1).join(' ').trim();
+        if (/^-r?f?r?\s*\/?(\*|\/)?$/i.test(tail) || tail === '-rf /' || tail === '-rf /*' || tail === '-fr /') {
+          void showRmRf();
+        } else if (!tail) {
+          addLine('rm: missing operand', 'text-tui-error');
+          addLine("try 'rm --help' for more information.", 'text-tui-muted');
+          setLastExitCode(1);
+        } else {
+          addLine(`rm: cannot remove '${tail}': Permission denied`, 'text-tui-error');
+          setLastExitCode(1);
+        }
+        break;
+      }
       case 'stats':
         showStats();
         break;
@@ -2621,7 +2730,7 @@ export function useTerminal({ portfolioData, onSwitchToGUI, onTriggerMatrix }: U
         );
         setLastExitCode(127);
     }
-  }, [addLine, addNode, showHelp, openResumePdf, showWelcomeMessage, showAbout, showSkills, showExperience, showEducation, showProjects, showPersonalProjects, showContact, showPublications, showTimeline, showSearch, showTheme, showWhoAmI, listCommands, showCat, showNeofetch, showReplicate, showHistory, clearTerminal, showGenericSection, showQuote, showCoffee, showSudo, showMatrix, showKonami, showStats, linkRegistry, portfolioData, onSwitchToGUI, currentDir]);
+  }, [addLine, addNode, showHelp, openResumePdf, showWelcomeMessage, showAbout, showSkills, showExperience, showEducation, showProjects, showPersonalProjects, showContact, showPublications, showTimeline, showSearch, showTheme, showWhoAmI, listCommands, showCat, showNeofetch, showReplicate, showHistory, clearTerminal, showGenericSection, showQuote, showCoffee, showSudo, showMatrix, showKonami, showStats, showRmRf, linkRegistry, portfolioData, onSwitchToGUI, currentDir]);
 
   const navigateHistory = useCallback((direction: 'up' | 'down') => {
     if (commandHistory.length === 0) return currentInput;

--- a/client/src/hooks/useTerminal.tsx
+++ b/client/src/hooks/useTerminal.tsx
@@ -254,20 +254,23 @@ async function getWelcomeNode(portfolioData: PortfolioData): Promise<ReactNode> 
       <div className="mb-3 sm:mb-4">
         {usePre ? (
           <>
-            <div className="hidden sm:block border border-terminal-green/30 rounded-sm px-4 py-2 max-w-4xl overflow-x-auto">
+            {/* Banner uses a left-rail treatment (no top/right/bottom
+                border, no rounded corners) to match the Block family's
+                chrome. The banner is atmospheric, not a container. */}
+            <div className="hidden sm:block border-l-[3px] border-l-terminal-bright-green pl-3 max-w-4xl overflow-x-auto">
               <pre className="text-terminal-bright-green text-xs leading-tight">
                 {styledName}
               </pre>
             </div>
-            <div className="sm:hidden text-terminal-bright-green text-center mb-3">
-              <div className="text-lg font-bold">{cv.name.toUpperCase()}</div>
-              <div className="text-sm">TERMINAL PORTFOLIO</div>
+            <div className="sm:hidden text-terminal-bright-green mb-3 border-l-[3px] border-l-terminal-bright-green pl-3">
+              <div className="text-lg font-bold">{cv.name.toLowerCase()}</div>
+              <div className="text-xs text-tui-accent-dim">// terminal portfolio</div>
             </div>
           </>
         ) : (
-          <div className="text-terminal-bright-green text-center mb-3">
-            <div className="text-lg font-bold">{cv.name.toUpperCase()}</div>
-            <div className="text-sm">TERMINAL PORTFOLIO</div>
+          <div className="text-terminal-bright-green mb-3 border-l-[3px] border-l-terminal-bright-green pl-3">
+            <div className="text-lg font-bold">{cv.name.toLowerCase()}</div>
+            <div className="text-xs text-tui-accent-dim">// terminal portfolio</div>
           </div>
         )}
       </div>
@@ -279,7 +282,7 @@ async function getWelcomeNode(portfolioData: PortfolioData): Promise<ReactNode> 
       </div>
 
       <SectionBox
-        title="// overview"
+        title="// identity"
         bodyClassName="p-3 space-y-1 text-xs sm:text-sm"
         className="max-w-none"
       >
@@ -1360,15 +1363,15 @@ export function useTerminal({ portfolioData, onSwitchToGUI, onTriggerMatrix }: U
     };
 
     const stats = [
-      { value: portfolioData.cv.sections?.experience?.length ?? 0, label: 'Positions' },
-      { value: portfolioData.cv.sections?.education?.length ?? 0, label: 'Degrees' },
+      { value: portfolioData.cv.sections?.experience?.length ?? 0, label: 'positions' },
+      { value: portfolioData.cv.sections?.education?.length ?? 0, label: 'degrees' },
       {
         value:
           (portfolioData.cv.sections?.professional_projects?.length ?? 0) +
           (portfolioData.cv.sections?.personal_projects?.length ?? 0),
-        label: 'Projects',
+        label: 'projects',
       },
-      { value: portfolioData.cv.sections?.publication?.length ?? 0, label: 'Publications' },
+      { value: portfolioData.cv.sections?.publication?.length ?? 0, label: 'publications' },
     ];
 
     addNode(
@@ -1432,7 +1435,7 @@ export function useTerminal({ portfolioData, onSwitchToGUI, onTriggerMatrix }: U
               {stats.map((s) => (
                 <div key={s.label} className="border-l-2 border-tui-accent-dim/40 pl-2">
                   <div className="text-terminal-bright-green text-lg tabular-nums">{s.value}</div>
-                  <div className="text-tui-muted text-xs uppercase tracking-wide">{s.label}</div>
+                  <div className="text-tui-muted text-xs">{s.label}</div>
                 </div>
               ))}
             </div>
@@ -1710,7 +1713,10 @@ export function useTerminal({ portfolioData, onSwitchToGUI, onTriggerMatrix }: U
           <div className="space-y-1 ml-1">
             <Row label="Name" value={cv.name} />
             <Row label="Location" value={cv.location} />
-            <Row label="Email" value={cv.email} />
+            <Row
+              label="Email"
+              value={<ExtLink href={`mailto:${cv.email}`}>{cv.email}</ExtLink>}
+            />
             <Row
               label="Phone"
               value={
@@ -2142,7 +2148,12 @@ export function useTerminal({ portfolioData, onSwitchToGUI, onTriggerMatrix }: U
       // render at the same width as figure space in most monospace fonts,
       // which jags the right edges of the ASCII boxes. Normalise any
       // Unicode space variant to a regular space inside the <pre>.
-      const normalised = neofetchContent.replace(/[\u00A0\u2000-\u200B\u202F\u205F\u3000]/g, ' ');
+      const normalised = neofetchContent
+        .replace(/[\u00A0\u2000-\u200B\u202F\u205F\u3000]/g, ' ')
+        // Strip inline markdown — the <pre> doesn't parse it,
+        // so `[text](url)` leaked into the rendered banner as
+        // literal brackets. Collapse to bare text.
+        .replace(/\[([^\]]+)\]\((https?:\/\/[^)]+)\)/g, '$1');
 
       addNode(
         <pre className="font-mono text-terminal-green whitespace-pre text-xs sm:text-sm leading-tight overflow-x-auto">
@@ -2156,30 +2167,34 @@ export function useTerminal({ portfolioData, onSwitchToGUI, onTriggerMatrix }: U
   }, [addLine, addNode, portfolioData, showNeofetchFallback]);
 
   const listCommands = useCallback(() => {
-    const commands = getAllCommandNames();
+    // Visible-only: hidden commands (quote/coffee/matrix/konami/rm/
+    // sudo/open/o/g) are discoverable via autocomplete, not ls.
+    const visible = getAvailableCommands()
+      .filter((c) => !c.hidden)
+      .map((c) => c.name);
     addNode(
       <Block title="// ls">
         <div className="grid grid-cols-2 sm:grid-cols-3 md:grid-cols-4 gap-x-4 gap-y-0.5 text-xs sm:text-sm font-mono">
-          {commands.map((cmd) => (
+          {visible.map((cmd) => (
             <CmdLink key={cmd} cmd={cmd} className="text-terminal-green font-normal">
               {cmd}
             </CmdLink>
           ))}
         </div>
         <div className="pt-2 mt-2 border-t border-tui-accent-dim/30 text-xs text-tui-muted">
-          {commands.length} commands · try <CmdLink cmd="help" className="text-tui-accent-dim">help</CmdLink> for descriptions
+          {visible.length} commands · try <CmdLink cmd="help" className="text-tui-accent-dim">help</CmdLink> for descriptions
         </div>
       </Block>,
       'w-full',
     );
-  }, [addNode, getAllCommandNames]);
+  }, [addNode, getAvailableCommands]);
 
   const showHistory = useCallback((args: string[]) => {
     if (args[0] === 'clear') {
       setCommandHistory([]);
       setHistoryIndex(-1);
       storage.remove(storageConfig.keys.commandHistory);
-      addLine('Command history cleared.', 'text-terminal-yellow');
+      addLine('command history cleared.', 'text-tui-accent-dim');
       return;
     }
 

--- a/client/src/hooks/useTerminal.tsx
+++ b/client/src/hooks/useTerminal.tsx
@@ -295,7 +295,7 @@ async function getWelcomeNode(portfolioData: PortfolioData): Promise<ReactNode> 
 }
 
 // Command Registry Types and Definitions
-interface CommandMetadata {
+export interface CommandMetadata {
   name: string;
   description: string;
   category: 'information' | 'professional' | 'contact' | 'tools' | 'terminal';
@@ -306,6 +306,8 @@ interface CommandMetadata {
   isAvailable?: (data: PortfolioData | null) => boolean;
   /** Command aliases */
   aliases?: string[];
+  /** Hint for argument completion, e.g. `[term]` or `[theme-name]`. */
+  argsHint?: string;
 }
 
 const COMMAND_REGISTRY: CommandMetadata[] = [
@@ -370,8 +372,8 @@ const COMMAND_REGISTRY: CommandMetadata[] = [
   { name: 'contact', description: 'Get in touch with me', category: 'contact' },
 
   // TOOLS Commands (always available)
-  { name: 'search', description: 'Search through my portfolio content', category: 'tools' },
-  { name: 'theme', description: 'Change terminal color theme', category: 'tools' },
+  { name: 'search', description: 'Search through my portfolio content', category: 'tools', argsHint: '[term]' },
+  { name: 'theme', description: 'Change terminal color theme', category: 'tools', argsHint: '[name]' },
   { name: 'gui', description: 'Switch to the GUI portfolio view', category: 'tools' },
   { name: 'replicate', description: 'Create your own terminal portfolio', category: 'tools', aliases: ['clone', 'fork'] },
 
@@ -380,7 +382,7 @@ const COMMAND_REGISTRY: CommandMetadata[] = [
   { name: 'history', description: 'Show recent commands (click to re-run)', category: 'terminal' },
   { name: 'ls', description: 'List available commands', category: 'terminal' },
   { name: 'pwd', description: 'Print working directory', category: 'terminal' },
-  { name: 'cat', description: 'Display file contents', category: 'terminal' },
+  { name: 'cat', description: 'Display file contents', category: 'terminal', argsHint: '[file]' },
 ];
 
 export function useTerminal({ portfolioData, onSwitchToGUI }: UseTerminalProps) {
@@ -2353,5 +2355,8 @@ export function useTerminal({ portfolioData, onSwitchToGUI }: UseTerminalProps) 
     promptHost: terminalConfig.prompt.hostname,
     // Used by the status bar to render live counts.
     historyLength: commandHistory.length,
+    // Exposed for the command palette (phase 6).
+    getCommandMetadata: getAvailableCommands,
+    recentCommands: commandHistory,
   };
 }

--- a/client/src/hooks/useTerminal.tsx
+++ b/client/src/hooks/useTerminal.tsx
@@ -14,6 +14,7 @@ import { ExploreMore } from '../components/tui/ExploreMore';
 import { CollapsibleGroup, type CollapsibleItemData } from '../components/tui/Collapsible';
 import { ReplicatePage } from '../components/tui/ReplicatePage';
 import { LabeledRow, CompactRow } from '../components/tui/LabeledRow';
+import { MarkdownBlock } from '../components/tui/MarkdownBlock';
 import type { TerminalLinkRegistry, TerminalLink } from '../components/tui/LinkRegistry';
 // Import specific date-fns functions for better tree-shaking
 import { parse } from 'date-fns/parse';
@@ -118,9 +119,13 @@ function getProjectsNode(
           {((project.highlights as string[]) || []).map((highlight, i) => (
             <div
               key={i}
-              className="text-white text-xs leading-relaxed bg-terminal-green/5 p-2 rounded"
-              dangerouslySetInnerHTML={{ __html: `• ${inlineMd(highlight)}` }}
-            />
+              className="text-xs leading-relaxed border-l-2 border-tui-accent-dim/40 pl-3 flex gap-2"
+            >
+              <span className="text-tui-accent-dim shrink-0">·</span>
+              <div className="flex-1">
+                <MarkdownBlock source={highlight} inline />
+              </div>
+            </div>
           ))}
         </div>
         <div
@@ -205,10 +210,9 @@ async function getWelcomeNode(portfolioData: PortfolioData): Promise<ReactNode> 
       </div>
       <div className="mb-4">
         <p className="text-terminal-green mb-2 text-sm sm:text-base">{uiText.welcome.greeting}</p>
-        <p
-          className="text-white/80 mb-2 text-xs sm:text-sm leading-relaxed"
-          dangerouslySetInnerHTML={{ __html: inlineMd(introParagraph) }}
-        />
+        <div className="text-white/80 mb-2 text-xs sm:text-sm leading-relaxed">
+          <MarkdownBlock source={introParagraph} inline />
+        </div>
       </div>
 
       <SectionBox
@@ -704,11 +708,9 @@ export function useTerminal({ portfolioData, onSwitchToGUI }: UseTerminalProps) 
           <div className="text-tui-accent-dim text-xs mb-2">// intro</div>
           <div className="space-y-2 ml-1">
             {(cv.sections?.intro ?? []).map((paragraph, i) => (
-              <div
-                key={i}
-                className="text-white leading-relaxed border-l-2 border-tui-accent-dim/40 pl-3"
-                dangerouslySetInnerHTML={{ __html: inlineMd(paragraph) }}
-              />
+              <div key={i} className="border-l-2 border-tui-accent-dim/40 pl-3">
+                <MarkdownBlock source={paragraph} inline />
+              </div>
             ))}
           </div>
         </div>
@@ -787,16 +789,18 @@ export function useTerminal({ portfolioData, onSwitchToGUI }: UseTerminalProps) 
     }) => (
       <div className="ml-2">
         {label && (
-          <div className="text-terminal-bright-green font-semibold mb-2 text-xs">{label}</div>
+          <div className="text-tui-accent-dim text-xs mb-2">// {label.replace(/:/g, '').toLowerCase()}</div>
         )}
         <div className="space-y-1">
           {items.map((h, hi) => (
             <div
               key={hi}
-              className="text-white text-xs leading-relaxed bg-terminal-green/5 p-2 rounded"
+              className="text-xs leading-relaxed border-l-2 border-tui-accent-dim/40 pl-3 flex gap-2"
             >
-              {'• '}
-              <span dangerouslySetInnerHTML={{ __html: inlineMd(h) }} />
+              <span className="text-tui-accent-dim shrink-0">·</span>
+              <div className="flex-1">
+                <MarkdownBlock source={h} inline />
+              </div>
             </div>
           ))}
         </div>
@@ -893,13 +897,12 @@ export function useTerminal({ portfolioData, onSwitchToGUI }: UseTerminalProps) 
         return (
           <div key={index} className={`pb-2 ${isLast ? '' : 'border-b border-terminal-green/20'}`}>
             <div className="flex gap-2">
-              <span className="text-terminal-yellow font-semibold min-w-[100px]">
+              <span className="text-tui-accent-dim font-semibold min-w-[100px]">
                 {item.label as string}:
               </span>
-              <span
-                className="text-white"
-                dangerouslySetInnerHTML={{ __html: inlineMd(item.details as string) }}
-              />
+              <span className="text-white/90">
+                <MarkdownBlock source={item.details as string} inline />
+              </span>
             </div>
             <span
               dangerouslySetInnerHTML={{ __html: renderCustomFields(item, 'technologies') }}
@@ -944,14 +947,11 @@ export function useTerminal({ portfolioData, onSwitchToGUI }: UseTerminalProps) 
         <div className="space-y-1 ml-2">
           {techs.map((tech, i) => (
             <div key={i} className="grid grid-cols-1 md:grid-cols-12 gap-1 md:gap-2">
-              <div className="md:col-span-3 bg-terminal-green/10 p-2 rounded">
-                <span className="text-terminal-yellow font-semibold mb-1">{tech.label}</span>
+              <div className="md:col-span-3">
+                <span className="text-tui-accent-dim font-semibold">{tech.label}</span>
               </div>
-              <div className="md:col-span-9 bg-terminal-green/5 p-2 rounded ml-3">
-                <span
-                  className="text-white"
-                  dangerouslySetInnerHTML={{ __html: inlineMd(tech.details) }}
-                />
+              <div className="md:col-span-9 border-l-2 border-tui-accent-dim/40 pl-3">
+                <MarkdownBlock source={tech.details} inline />
               </div>
             </div>
           ))}
@@ -1005,17 +1005,19 @@ export function useTerminal({ portfolioData, onSwitchToGUI }: UseTerminalProps) 
                 </div>
               </div>
               <div className="ml-2">
-                <div className="text-terminal-bright-green font-semibold mb-2 text-xs">
-                  Key Achievements:
+                <div className="text-tui-accent-dim text-xs mb-2">
+                  // highlights
                 </div>
                 <div className="space-y-1">
                   {job.highlights.map((highlight, hi) => (
                     <div
                       key={hi}
-                      className="text-white text-xs leading-relaxed bg-terminal-green/5 p-2 rounded"
+                      className="text-xs leading-relaxed border-l-2 border-tui-accent-dim/40 pl-3 flex gap-2"
                     >
-                      {'• '}
-                      <span dangerouslySetInnerHTML={{ __html: inlineMd(highlight) }} />
+                      <span className="text-tui-accent-dim shrink-0">·</span>
+                      <div className="flex-1">
+                        <MarkdownBlock source={highlight} inline />
+                      </div>
                     </div>
                   ))}
                 </div>
@@ -1082,10 +1084,12 @@ export function useTerminal({ portfolioData, onSwitchToGUI }: UseTerminalProps) 
                     {edu.highlights.map((highlight, hi) => (
                       <div
                         key={hi}
-                        className="text-white text-xs leading-relaxed bg-terminal-green/5 p-2 rounded"
+                        className="text-xs leading-relaxed border-l-2 border-tui-accent-dim/40 pl-3 flex gap-2"
                       >
-                        {'• '}
-                        <span dangerouslySetInnerHTML={{ __html: inlineMd(highlight) }} />
+                        <span className="text-tui-accent-dim shrink-0">·</span>
+                        <div className="flex-1">
+                          <MarkdownBlock source={highlight} inline />
+                        </div>
                       </div>
                     ))}
                   </div>
@@ -1791,11 +1795,13 @@ export function useTerminal({ portfolioData, onSwitchToGUI }: UseTerminalProps) 
 
     const { cv } = portfolioData;
 
-    const Bullet = ({ html }: { html: string }) => (
-      <div
-        className="text-white text-xs leading-relaxed border-l-2 border-tui-accent-dim/40 pl-3"
-        dangerouslySetInnerHTML={{ __html: `· ${html}` }}
-      />
+    const Bullet = ({ md }: { md: string }) => (
+      <div className="text-xs leading-relaxed border-l-2 border-tui-accent-dim/40 pl-3 flex gap-2">
+        <span className="text-tui-accent-dim shrink-0">·</span>
+        <div className="flex-1">
+          <MarkdownBlock source={md} inline />
+        </div>
+      </div>
     );
 
     const items: CollapsibleItemData[] = [];
@@ -1803,15 +1809,16 @@ export function useTerminal({ portfolioData, onSwitchToGUI }: UseTerminalProps) 
     if (cv.sections?.intro?.length) {
       items.push({
         id: 'about',
-        header: <span className="text-terminal-yellow font-semibold">About</span>,
+        header: <span className="text-tui-accent-dim font-semibold">about</span>,
         content: (
-          <div className="space-y-1">
+          <div className="space-y-2">
             {cv.sections.intro.map((line, i) => (
               <div
                 key={i}
-                className="text-white text-xs leading-relaxed bg-terminal-green/5 p-2 rounded"
-                dangerouslySetInnerHTML={{ __html: inlineMd(line) }}
-              />
+                className="text-xs leading-relaxed border-l-2 border-tui-accent-dim/40 pl-3"
+              >
+                <MarkdownBlock source={line} inline />
+              </div>
             ))}
           </div>
         ),
@@ -1821,17 +1828,18 @@ export function useTerminal({ portfolioData, onSwitchToGUI }: UseTerminalProps) 
     if (cv.sections?.technologies?.length) {
       items.push({
         id: 'technologies',
-        header: <span className="text-terminal-yellow font-semibold">Technologies</span>,
+        header: <span className="text-tui-accent-dim font-semibold">technologies</span>,
         content: (
           <div className="space-y-1">
             {cv.sections.technologies.map((tech, i) => (
               <div
                 key={i}
-                className="text-white text-xs leading-relaxed bg-terminal-green/5 p-2 rounded"
+                className="text-xs leading-relaxed border-l-2 border-tui-accent-dim/40 pl-3"
               >
-                <span className="text-terminal-yellow font-semibold">• {tech.label}</span>
-                <span className="text-white">
-                  {' '}- <span dangerouslySetInnerHTML={{ __html: inlineMd(tech.details) }} />
+                <span className="text-terminal-bright-green">{tech.label}</span>
+                <span className="text-white/80"> — </span>
+                <span className="text-white/90">
+                  <MarkdownBlock source={tech.details} inline />
                 </span>
               </div>
             ))}
@@ -1861,7 +1869,7 @@ export function useTerminal({ portfolioData, onSwitchToGUI }: UseTerminalProps) 
                   {exp.highlights?.length > 0 && (
                     <div className="space-y-1">
                       {exp.highlights.map((h, j) => (
-                        <Bullet key={j} html={inlineMd(h)} />
+                        <Bullet key={j} md={h} />
                       ))}
                     </div>
                   )}
@@ -1891,7 +1899,7 @@ export function useTerminal({ portfolioData, onSwitchToGUI }: UseTerminalProps) 
                 {(edu.highlights?.length ?? 0) > 0 && (
                   <div className="space-y-1 mt-2">
                     {edu.highlights?.map((h, j) => (
-                      <Bullet key={j} html={inlineMd(h)} />
+                      <Bullet key={j} md={h} />
                     ))}
                   </div>
                 )}
@@ -1923,7 +1931,7 @@ export function useTerminal({ portfolioData, onSwitchToGUI }: UseTerminalProps) 
                 {project.highlights?.length > 0 && (
                   <div className="space-y-1">
                     {project.highlights.map((h, j) => (
-                      <Bullet key={j} html={inlineMd(h)} />
+                      <Bullet key={j} md={h} />
                     ))}
                   </div>
                 )}

--- a/client/src/hooks/useTerminal.tsx
+++ b/client/src/hooks/useTerminal.tsx
@@ -1,4 +1,4 @@
-import { useState, useCallback, useEffect, useRef, type ReactNode } from 'react';
+import { useState, useCallback, useEffect, useMemo, useRef, type ReactNode } from 'react';
 import { type PortfolioData } from '../../../shared/schema';
 import { formatExperiencePeriod, getSocialNetworkUrl } from '../lib/portfolioData';
 import { themes } from '../lib/themes';
@@ -14,6 +14,7 @@ import { ExploreMore } from '../components/tui/ExploreMore';
 import { CollapsibleGroup, type CollapsibleItemData } from '../components/tui/Collapsible';
 import { ReplicatePage } from '../components/tui/ReplicatePage';
 import { LabeledRow, CompactRow } from '../components/tui/LabeledRow';
+import type { TerminalLinkRegistry, TerminalLink } from '../components/tui/LinkRegistry';
 // Import specific date-fns functions for better tree-shaking
 import { parse } from 'date-fns/parse';
 
@@ -405,6 +406,34 @@ export function useTerminal({ portfolioData, onSwitchToGUI }: UseTerminalProps) 
   const [lastExitCode, setLastExitCode] = useState<number | null>(null);
   const lineIdCounter = useRef(0);
 
+  // Terminal-wide numbered link registry. Consumed by NumberedLink for
+  // display, by Terminal.tsx for `o N` / `g N` resolution. Resets on
+  // `clear`. Numbers are href-keyed and stable across re-renders.
+  const linkCounter = useRef(0);
+  const linkMap = useRef<Map<number, TerminalLink>>(new Map());
+  const linkHrefIndex = useRef<Map<string, number>>(new Map());
+
+  const linkRegistry = useMemo<TerminalLinkRegistry>(
+    () => ({
+      register: (href: string, label: string) => {
+        const existing = linkHrefIndex.current.get(href);
+        if (existing !== undefined) return existing;
+        const n = ++linkCounter.current;
+        linkMap.current.set(n, { n, href, label });
+        linkHrefIndex.current.set(href, n);
+        return n;
+      },
+      resolve: (n: number) => linkMap.current.get(n),
+      all: () => Array.from(linkMap.current.values()),
+      reset: () => {
+        linkCounter.current = 0;
+        linkMap.current.clear();
+        linkHrefIndex.current.clear();
+      },
+    }),
+    [],
+  );
+
   const generateId = () => `line-${++lineIdCounter.current}`;
 
   // Cap scrollback so the DOM doesn't grow unbounded on long sessions.
@@ -438,7 +467,8 @@ export function useTerminal({ portfolioData, onSwitchToGUI }: UseTerminalProps) 
   const clearTerminal = useCallback(() => {
     setLines([]);
     setCurrentDir('~');
-  }, []);
+    linkRegistry.reset();
+  }, [linkRegistry]);
 
   /** Commands that represent a "navigation" — they change the prompt
    *  context to `~/<cmd>`. Utility commands (ls, pwd, history, theme,
@@ -600,6 +630,16 @@ export function useTerminal({ portfolioData, onSwitchToGUI }: UseTerminalProps) 
             <div>
               <span className="text-tui-accent-dim">· </span>
               click anywhere to focus input
+            </div>
+            <div>
+              <span className="text-tui-accent-dim">· </span>
+              <span className="text-terminal-bright-green font-mono">o N</span> or{' '}
+              <span className="text-terminal-bright-green font-mono">g N</span> to open link{' '}
+              <span className="text-tui-muted">[N]</span>
+            </div>
+            <div>
+              <span className="text-tui-accent-dim">· </span>
+              <span className="text-terminal-bright-green font-mono">ctrl+k</span> opens the command palette
             </div>
           </div>
         </div>
@@ -2358,5 +2398,8 @@ export function useTerminal({ portfolioData, onSwitchToGUI }: UseTerminalProps) 
     // Exposed for the command palette (phase 6).
     getCommandMetadata: getAvailableCommands,
     recentCommands: commandHistory,
+    // Link registry — consumed by NumberedLink + Terminal.tsx's
+    // `o N` / `g N` keyboard resolver (phase 7).
+    linkRegistry,
   };
 }

--- a/client/src/hooks/useTerminal.tsx
+++ b/client/src/hooks/useTerminal.tsx
@@ -33,9 +33,15 @@ export interface TerminalLine {
 export interface UseTerminalProps {
   portfolioData: PortfolioData | null;
   onSwitchToGUI?: () => void;
-  /** Called by the `matrix` command to trigger the idle-rain overlay
-   *  on demand. Terminal.tsx wires this to setMatrixActive(true). */
-  onTriggerMatrix?: () => void;
+  /** Called by the `matrix` command to trigger the idle-rain overlay.
+   *  Pass `{ persist: true }` for `matrix on` (rain stays through key
+   *  presses); omit / pass `false` for the default one-shot summon
+   *  (any input dismisses). Terminal.tsx maps this to setMatrixActive
+   *  + setMatrixPersistent. */
+  onTriggerMatrix?: (opts?: { persist?: boolean }) => void;
+  /** Called by `matrix off` to explicitly dismiss + clear the
+   *  persistent flag. */
+  onDismissMatrix?: () => void;
 }
 
 function getUsername(portfolioData: PortfolioData, network: string): string | undefined {
@@ -254,28 +260,26 @@ async function getWelcomeNode(portfolioData: PortfolioData): Promise<ReactNode> 
       <div className="mb-3 sm:mb-4">
         {usePre ? (
           <>
-            {/* Banner uses a left-rail treatment (no top/right/bottom
-                border, no rounded corners) to match the Block family's
-                chrome. The banner is atmospheric, not a container. */}
-            <div className="hidden sm:block border-l-[3px] border-l-terminal-bright-green pl-3 max-w-4xl overflow-x-auto">
+            {/* ASCII banner stands on its own — the left rail used to
+                read as a redundant frame around already-fenced art. */}
+            <div className="hidden sm:block max-w-4xl overflow-x-auto">
               <pre className="text-terminal-bright-green text-xs leading-tight">
                 {styledName}
               </pre>
             </div>
-            <div className="sm:hidden text-terminal-bright-green mb-3 border-l-[3px] border-l-terminal-bright-green pl-3">
+            <div className="sm:hidden text-terminal-bright-green mb-3">
               <div className="text-lg font-bold">{cv.name.toLowerCase()}</div>
               <div className="text-xs text-tui-accent-dim">// terminal portfolio</div>
             </div>
           </>
         ) : (
-          <div className="text-terminal-bright-green mb-3 border-l-[3px] border-l-terminal-bright-green pl-3">
+          <div className="text-terminal-bright-green mb-3">
             <div className="text-lg font-bold">{cv.name.toLowerCase()}</div>
             <div className="text-xs text-tui-accent-dim">// terminal portfolio</div>
           </div>
         )}
       </div>
       <div className="mb-4">
-        <p className="text-terminal-green mb-2 text-sm sm:text-base">{uiText.welcome.greeting}</p>
         <div className="text-white/80 mb-2 text-xs sm:text-sm leading-relaxed">
           <MarkdownBlock source={introParagraph} inline />
         </div>
@@ -452,7 +456,7 @@ const COMMAND_REGISTRY: CommandMetadata[] = [
   { name: 'open', description: 'Open link by number', category: 'tools', hidden: true, aliases: ['o', 'g'], argsHint: '<N>' },
 ];
 
-export function useTerminal({ portfolioData, onSwitchToGUI, onTriggerMatrix }: UseTerminalProps) {
+export function useTerminal({ portfolioData, onSwitchToGUI, onTriggerMatrix, onDismissMatrix }: UseTerminalProps) {
   const [lines, setLines] = useState<TerminalLine[]>([]);
   const [commandHistory, setCommandHistory] = useState<string[]>(() => {
     // Rehydrate from localStorage so the history command + arrow-key
@@ -537,13 +541,16 @@ export function useTerminal({ portfolioData, onSwitchToGUI, onTriggerMatrix }: U
   }, [linkRegistry]);
 
   /** Commands that represent a "navigation" — they change the prompt
-   *  context to `~/<cmd>`. Utility commands (ls, pwd, history, theme,
-   *  search, clear, gui, resume, help) don't move the user anywhere.
-   *  `welcome` resets to `~/` since that's the landing state. */
+   *  context to `~/<cmd>`. Utility / lookup commands (ls, pwd, history,
+   *  theme, search, clear, gui, resume, help, whoami, neofetch, stats)
+   *  don't move the user anywhere — they're print-and-return ops, not
+   *  section views, and pinning them to `~/whoami` reads as a duplicate
+   *  next to the command echo. `welcome` resets to `~/` since that's
+   *  the landing state. */
   const DESTINATION_COMMANDS = new Set([
     'about', 'skills', 'experience', 'education', 'projects',
-    'personal', 'publications', 'timeline', 'contact', 'whoami',
-    'neofetch', 'replicate', 'clone', 'fork', 'stats',
+    'personal', 'publications', 'timeline', 'contact',
+    'replicate', 'clone', 'fork',
   ]);
 
   // Get available commands based on portfolio data
@@ -2408,17 +2415,27 @@ export function useTerminal({ portfolioData, onSwitchToGUI, onTriggerMatrix }: U
     addLine('sorry, no sudo for you.', 'text-tui-accent-dim');
   }, [addLine]);
 
-  const showMatrix = useCallback(() => {
-    if (onTriggerMatrix) {
-      addLine('// matrix — rain summoned. any key dismisses.', 'text-terminal-bright-green');
-      onTriggerMatrix();
-    } else {
-      addLine(
-        'matrix screensaver: idle for 30s to see it.',
-        'text-tui-accent-dim',
-      );
+  const showMatrix = useCallback((mode?: 'on' | 'off') => {
+    if (mode === 'off') {
+      if (onDismissMatrix) onDismissMatrix();
+      addLine('// matrix — rain dismissed.', 'text-tui-accent-dim');
+      return;
     }
-  }, [addLine, onTriggerMatrix]);
+    if (!onTriggerMatrix) {
+      addLine('matrix screensaver: idle for 30s to see it.', 'text-tui-accent-dim');
+      return;
+    }
+    if (mode === 'on') {
+      addLine(
+        '// matrix — rain pinned. type `matrix off` to dismiss.',
+        'text-terminal-bright-green',
+      );
+      onTriggerMatrix({ persist: true });
+    } else {
+      addLine('// matrix — rain summoned. any key dismisses.', 'text-terminal-bright-green');
+      onTriggerMatrix({ persist: false });
+    }
+  }, [addLine, onTriggerMatrix, onDismissMatrix]);
 
   const showStats = useCallback(async () => {
     // Fetch the live pypi-stats.json; same source as the GUI hero.
@@ -2585,6 +2602,18 @@ export function useTerminal({ portfolioData, onSwitchToGUI, onTriggerMatrix }: U
     if (DESTINATION_COMMANDS.has(cmd)) {
       // Normalise aliases to their canonical dir (clone/fork → replicate).
       const canonical = cmd === 'clone' || cmd === 'fork' ? 'replicate' : cmd;
+      // Already viewing this section — re-running just duplicates the
+      // identical block. Friendly nudge instead of redundant output.
+      // No-arg only; with args (e.g. `theme blue`) the command is doing
+      // real work, not just navigating.
+      if (currentDir === `~/${canonical}` && args.length === 1) {
+        addLine(
+          `// already viewing ${canonical} — type 'clear' to reset, or scroll up`,
+          'text-tui-muted',
+        );
+        setLastExitCode(0);
+        return;
+      }
       setCurrentDir(`~/${canonical}`);
     } else if (cmd === 'welcome') {
       setCurrentDir('~');
@@ -2682,24 +2711,76 @@ export function useTerminal({ portfolioData, onSwitchToGUI, onTriggerMatrix }: U
       case 'sudo':
         showSudo(args.slice(1));
         break;
-      case 'matrix':
-        showMatrix();
+      case 'matrix': {
+        const sub = (args[1] ?? '').toLowerCase();
+        if (sub === 'on' || sub === '--keep' || sub === '-k') {
+          showMatrix('on');
+        } else if (sub === 'off' || sub === 'stop' || sub === 'dismiss') {
+          showMatrix('off');
+        } else {
+          showMatrix();
+        }
         break;
+      }
       case 'konami':
         showKonami();
         break;
       case 'rm': {
         // The infamous command. Unix-faithful for anything that
         // isn't `-rf /`; full theater for the classic.
-        const tail = args.slice(1).join(' ').trim();
-        if (/^-r?f?r?\s*\/?(\*|\/)?$/i.test(tail) || tail === '-rf /' || tail === '-rf /*' || tail === '-fr /') {
+        const restArgs = args.slice(1);
+        // Split flags (anything starting with `-`) from operands so the
+        // error message reads like a real shell ("cannot remove 'd'",
+        // not "cannot remove '-rf d'"). Also lets us detect `-rf /`
+        // regardless of flag/operand order.
+        const flagTokens = restArgs.filter((a) => a.startsWith('-'));
+        const operandTokens = restArgs.filter((a) => !a.startsWith('-') && a !== '');
+        const flagChars = flagTokens
+          .filter((f) => !f.startsWith('--'))
+          .map((f) => f.slice(1).toLowerCase())
+          .join('');
+        const hasR = flagChars.includes('r') || flagTokens.includes('--recursive');
+        const hasF = flagChars.includes('f') || flagTokens.includes('--force');
+        const targetsRoot = operandTokens.some((t) => t === '/' || t === '/*');
+        if (hasR && hasF && targetsRoot) {
           void showRmRf();
-        } else if (!tail) {
+        } else if (restArgs.length === 0) {
+          addLine('rm: missing operand', 'text-tui-error');
+          addLine("try 'rm --help' for more information.", 'text-tui-muted');
+          setLastExitCode(1);
+        } else if (flagTokens.includes('--help') || flagChars.includes('h')) {
+          // Real `rm` shows usage. Ours plays along — reads as a real
+          // shell page, with a wink at the bottom for the curious.
+          // Wrapped in <pre> so multi-space alignment survives.
+          addNode(
+            <pre className="font-mono whitespace-pre text-xs sm:text-sm leading-relaxed overflow-x-auto">
+              <span className="text-terminal-green">Usage: rm [OPTION]... FILE...{'\n'}</span>
+              <span className="text-tui-muted">
+                Remove (unlink) the FILE(s).{'\n'}
+                {'\n'}
+                {'  '}-f, --force            ignore nonexistent files, never prompt{'\n'}
+                {'  '}-i                     prompt before every removal{'\n'}
+                {'  '}-r, -R, --recursive    remove directories recursively{'\n'}
+                {'  '}-v, --verbose          explain what is being done{'\n'}
+                {'      '}--help             display this help and exit{'\n'}
+                {'\n'}
+              </span>
+              <span className="text-tui-accent-dim">
+                // note: this is a read-only portfolio. no file is ever actually removed.
+              </span>
+            </pre>,
+          );
+          setLastExitCode(0);
+        } else if (operandTokens.length === 0) {
+          // Only flags, no file — same error real `rm` gives.
           addLine('rm: missing operand', 'text-tui-error');
           addLine("try 'rm --help' for more information.", 'text-tui-muted');
           setLastExitCode(1);
         } else {
-          addLine(`rm: cannot remove '${tail}': Permission denied`, 'text-tui-error');
+          // Show one error per operand, just like real rm.
+          for (const op of operandTokens) {
+            addLine(`rm: cannot remove '${op}': Permission denied`, 'text-tui-error');
+          }
           setLastExitCode(1);
         }
         break;
@@ -2766,17 +2847,44 @@ export function useTerminal({ portfolioData, onSwitchToGUI, onTriggerMatrix }: U
 
   const getCommandSuggestions = useCallback((input: string) => {
     if (!input.trim()) return [];
-    const commands = getAllCommandNames();
-    // Source theme subcommands from the palette itself so new themes show
-    // up automatically. `reset` is kept as an explicit sentinel.
-    const themeSubCommands = [...colorThemes.map((t) => t.key), 'reset'];
-    const subCommands = ['cat resume.txt', ...themeSubCommands.map((color) => `theme ${color}`)];
+    // Subcommand maps — only surface AFTER the user has typed the
+    // base command followed by a space. Real shells don't suggest
+    // `matrix on` while you're still typing `matrix`.
+    const themeSubs = [...colorThemes.map((t) => t.key), 'reset'].map((c) => `theme ${c}`);
+    const matrixSubs = ['matrix on', 'matrix off'];
+    const catSubs = ['cat resume.txt'];
+    const subcommandGroups: Array<{ base: string; subs: string[] }> = [
+      { base: 'theme', subs: themeSubs },
+      { base: 'matrix', subs: matrixSubs },
+      { base: 'cat', subs: catSubs },
+    ];
+
     const lower = input.toLowerCase();
-    let matched = commands.filter((cmd) => cmd.startsWith(lower));
-    if (matched.length === 0) {
-      matched = subCommands.filter((cmd) => cmd.startsWith(lower));
+    const matched = new Set<string>();
+
+    // 1. Direct command-name matches — only when no space yet (i.e.,
+    // user is still picking the base command). Once a space is typed
+    // the user has committed to that command and is typing args.
+    if (!lower.includes(' ')) {
+      const commands = getAllCommandNames();
+      for (const cmd of commands) {
+        if (cmd.startsWith(lower)) matched.add(cmd);
+      }
     }
-    return matched;
+
+    // 2. Subcommand matches — gated on `${base} ` (with trailing space)
+    // so the dropdown stays empty while the base name is still being
+    // typed. Real terminals don't autosuggest subcommands; they wait
+    // for the base + space.
+    for (const { base, subs } of subcommandGroups) {
+      if (lower.startsWith(`${base} `)) {
+        for (const sub of subs) {
+          if (sub.startsWith(lower)) matched.add(sub);
+        }
+      }
+    }
+
+    return Array.from(matched);
   }, [getAllCommandNames]);
 
   const getAllCommands = useCallback(() => {

--- a/client/src/hooks/useTerminal.tsx
+++ b/client/src/hooks/useTerminal.tsx
@@ -5,7 +5,6 @@ import { themes } from '../lib/themes';
 import { colorThemes, applyColorTheme, cycleTheme } from '../config/gui-theme.config';
 import { uiText, formatMessage, apiConfig, terminalConfig, derivePromptUser, storage, storageConfig } from '../config';
 import { renderCustomFields } from '../lib/fieldRenderer';
-import { inlineMd } from '../lib/tuiMarkdown';
 import { Block } from '../components/tui/Block';
 import { SectionBox } from '../components/tui/SectionBox';
 import { CmdLink, ExtLink } from '../components/tui/TuiLink';

--- a/client/src/hooks/useTerminal.tsx
+++ b/client/src/hooks/useTerminal.tsx
@@ -6,6 +6,7 @@ import { colorThemes, applyColorTheme } from '../config/gui-theme.config';
 import { uiText, formatMessage, apiConfig, terminalConfig, storage, storageConfig } from '../config';
 import { renderCustomFields } from '../lib/fieldRenderer';
 import { inlineMd } from '../lib/tuiMarkdown';
+import { Block } from '../components/tui/Block';
 import { SectionBox } from '../components/tui/SectionBox';
 import { CmdLink, ExtLink } from '../components/tui/TuiLink';
 import { UsageHint } from '../components/tui/UsageHint';
@@ -1246,20 +1247,10 @@ export function useTerminal({ portfolioData, onSwitchToGUI }: UseTerminalProps) 
       return bEndDate.getTime() - aEndDate.getTime();
     }).reverse();
 
-    const getIcon = (type: string) => {
-      switch (type) {
-        case 'education': return '🎓';
-        case 'experience': return '💼';
-        case 'project': return '🚀';
-        case 'publication': return '📝';
-        default: return '•';
-      }
-    };
-
     const getTypeColor = (type: string) => {
       switch (type) {
         case 'education': return 'text-terminal-bright-green';
-        case 'experience': return 'text-terminal-yellow';
+        case 'experience': return 'text-tui-accent-dim';
         case 'project': return 'text-terminal-green';
         case 'publication': return 'text-terminal-white';
         default: return 'text-white';
@@ -1289,86 +1280,70 @@ export function useTerminal({ portfolioData, onSwitchToGUI }: UseTerminalProps) 
     ];
 
     addNode(
-      <div className="border border-terminal-green/50 rounded-sm mb-4 terminal-glow max-w-5xl">
-        <div className="border-b border-terminal-green/30 px-3 py-1 text-center">
-          <span className="text-terminal-bright-green text-sm font-bold">CAREER TIMELINE</span>
-        </div>
-        <div className="p-4">
-          <div className="relative">
-            <div className="absolute left-8 top-0 bottom-0 w-0.5 bg-gradient-to-b from-terminal-bright-green via-terminal-green to-terminal-green/30" />
+      <Block title="// timeline" wide>
+        <div className="relative">
+          <div className="absolute left-8 top-0 bottom-0 w-px bg-tui-accent-dim/50" />
 
-            <div className="space-y-6">
-              {timelineEvents.map((event, index) => {
-                const isOngoing = event.status === 'ongoing';
-                const duration = event.endDateStr
-                  ? `${formatDateForDisplay(event.dateStr)} - ${isOngoing ? uiText.labels.present : formatDateForDisplay(event.endDateStr)}`
-                  : formatDateForDisplay(event.dateStr);
-                return (
-                  <div key={index} className="relative flex items-start space-x-4 group">
-                    <div className="relative z-10">
-                      <div
-                        className={`w-4 h-4 rounded-full bg-terminal-green border-2 border-terminal-bright-green ${isOngoing ? 'animate-pulse shadow-lg shadow-terminal-green/50' : ''} group-hover:scale-125 transition-transform duration-200`}
-                      />
-                    </div>
+          <div className="space-y-5">
+            {timelineEvents.map((event, index) => {
+              const isOngoing = event.status === 'ongoing';
+              const duration = event.endDateStr
+                ? `${formatDateForDisplay(event.dateStr)} — ${isOngoing ? uiText.labels.present : formatDateForDisplay(event.endDateStr)}`
+                : formatDateForDisplay(event.dateStr);
+              return (
+                <div key={index} className="relative flex items-start space-x-4 group">
+                  <div className="relative z-10 pt-1">
+                    <div
+                      className={`w-3 h-3 bg-terminal-black border border-terminal-bright-green ${isOngoing ? 'animate-pulse shadow-[0_0_8px_rgba(var(--glow-color-rgb),0.6)]' : ''}`}
+                    />
+                  </div>
 
-                    <div className="flex-1 min-w-0 pb-4">
-                      <div className="bg-terminal-green/5 border border-terminal-green/20 rounded-lg p-4 group-hover:border-terminal-green/40 group-hover:bg-terminal-green/10 transition-all duration-200 ml-1">
-                        <div className="flex flex-wrap items-center gap-2 mb-2">
-                          <span className="text-lg">{getIcon(event.type)}</span>
-                          <span
-                            className={`text-xs px-2 py-1 rounded-full bg-terminal-green/20 ${getTypeColor(event.type)} font-semibold`}
-                          >
-                            {getTypeLabel(event.type)}
-                          </span>
-                          {isOngoing && (
-                            <span className="text-xs px-2 py-1 rounded-full bg-terminal-bright-green/20 text-terminal-bright-green font-semibold animate-pulse">
-                              CURRENT
-                            </span>
-                          )}
-                          <div className="text-xs text-white/70 font-mono sm:ml-auto">
-                            {duration}
-                          </div>
-                        </div>
-
-                        <div className="mb-2">
-                          <h3 className="text-terminal-bright-green font-semibold text-sm mb-1">
-                            {event.title}
-                          </h3>
-                          {event.subtitle && (
-                            <p className="text-terminal-yellow text-xs mb-1">{event.subtitle}</p>
-                          )}
-                          {event.description && (
-                            <p className="text-white/70 text-xs">{event.description}</p>
-                          )}
-                        </div>
-
+                  <div className="flex-1 min-w-0 pb-2">
+                    <div className="border-l-2 border-tui-accent-dim/40 pl-3 group-hover:border-terminal-bright-green transition-colors duration-150">
+                      <div className="flex flex-wrap items-baseline gap-x-2 gap-y-0.5 mb-1 text-xs font-mono">
+                        <span className={`${getTypeColor(event.type)} uppercase tracking-wide`}>
+                          {getTypeLabel(event.type).toLowerCase()}
+                        </span>
                         {isOngoing && (
-                          <div className="mt-2">
-                            <div className="h-1 bg-terminal-green/20 rounded-full overflow-hidden">
-                              <div className="h-full bg-gradient-to-r from-terminal-green to-terminal-bright-green animate-pulse rounded-full" />
-                            </div>
-                          </div>
+                          <span className="text-terminal-bright-green animate-pulse">
+                            · current
+                          </span>
+                        )}
+                        <span className="text-tui-muted sm:ml-auto tabular-nums">
+                          {duration}
+                        </span>
+                      </div>
+
+                      <div className="mb-1">
+                        <h3 className="text-terminal-bright-green text-sm">
+                          {event.title}
+                        </h3>
+                        {event.subtitle && (
+                          <p className="text-tui-accent-dim text-xs">{event.subtitle}</p>
+                        )}
+                        {event.description && (
+                          <p className="text-white/70 text-xs">{event.description}</p>
                         )}
                       </div>
                     </div>
                   </div>
-                );
-              })}
-            </div>
+                </div>
+              );
+            })}
+          </div>
 
-            <div className="mt-8 border-t border-terminal-green/30 pt-4">
-              <div className="grid grid-cols-2 md:grid-cols-4 gap-4 text-center">
-                {stats.map((s) => (
-                  <div key={s.label} className="bg-terminal-green/5 rounded-lg p-3">
-                    <div className="text-terminal-bright-green font-bold text-lg">{s.value}</div>
-                    <div className="text-white/70 text-xs">{s.label}</div>
-                  </div>
-                ))}
-              </div>
+          <div className="mt-6 border-t border-tui-accent-dim/30 pt-3">
+            <div className="grid grid-cols-2 md:grid-cols-4 gap-3">
+              {stats.map((s) => (
+                <div key={s.label} className="border-l-2 border-tui-accent-dim/40 pl-2">
+                  <div className="text-terminal-bright-green text-lg tabular-nums">{s.value}</div>
+                  <div className="text-tui-muted text-xs uppercase tracking-wide">{s.label}</div>
+                </div>
+              ))}
             </div>
           </div>
         </div>
-      </div>,
+      </Block>,
       'w-full',
     );
   }, [addLine, addNode, portfolioData]);
@@ -1670,25 +1645,17 @@ export function useTerminal({ portfolioData, onSwitchToGUI }: UseTerminalProps) 
             ))}
           </div>
         </div>
-        <div className="border-t border-terminal-green/30 pt-3">
-          <div className="text-terminal-yellow font-bold mb-2">💡 EXPLORE MORE</div>
-          <div className="space-y-1 ml-2 text-xs">
-            <div className="text-white leading-relaxed bg-terminal-green/5 p-2 rounded">
-              Feel free to reach out for collaborations, opportunities, or just to connect!
-            </div>
-            <div>
-              <span className="text-white">• </span>
-              Try <CmdLink cmd="about">about</CmdLink> to learn more about me
-            </div>
-            <div>
-              <span className="text-white">• </span>
-              Try <CmdLink cmd="projects">projects</CmdLink> to see my work
-            </div>
-            <div>
-              <span className="text-white">• </span>
-              Try <CmdLink cmd="experience">experience</CmdLink> for my professional background
-            </div>
+        <div className="border-t border-tui-accent-dim/30 pt-3">
+          <div className="text-white/80 leading-relaxed text-xs mb-3 border-l-2 border-tui-accent-dim/50 pl-3">
+            open to collaborations, new work, or a slow coffee chat.
           </div>
+          <ExploreMore
+            items={[
+              { cmd: 'about', suffix: 'to learn more about me' },
+              { cmd: 'projects', suffix: 'to see my work' },
+              { cmd: 'experience', suffix: 'for my professional background' },
+            ]}
+          />
         </div>
       </SectionBox>,
       'w-full',
@@ -1728,17 +1695,9 @@ export function useTerminal({ portfolioData, onSwitchToGUI }: UseTerminalProps) 
     }
 
     if (filename !== 'resume.txt') {
-      addNode(
-        <div className="border border-terminal-red/50 rounded-sm mb-4 terminal-glow max-w-4xl">
-          <div className="border-b border-terminal-red/30 px-3 py-1 text-center">
-            <span className="text-terminal-red text-sm font-bold">ERROR</span>
-          </div>
-          <div className="p-3 text-xs sm:text-sm">
-            <span className="text-terminal-red">cat: {filename}: No such file or directory</span>
-          </div>
-        </div>,
-        'w-full',
-      );
+      // Unix-literal — no bespoke red box. Matches the terse tone of
+      // every other shell error ("bash: foo: command not found").
+      addLine(`cat: ${filename}: No such file or directory`, 'text-tui-error');
       return;
     }
 
@@ -2081,18 +2040,19 @@ export function useTerminal({ portfolioData, onSwitchToGUI }: UseTerminalProps) 
   const listCommands = useCallback(() => {
     const commands = getAllCommandNames();
     addNode(
-      <div>
-        <div className="text-terminal-yellow font-bold mb-1">Available commands:</div>
-        <div className="space-y-0.5">
+      <Block title="// ls">
+        <div className="grid grid-cols-2 sm:grid-cols-3 md:grid-cols-4 gap-x-4 gap-y-0.5 text-xs sm:text-sm font-mono">
           {commands.map((cmd) => (
-            <div key={cmd}>
-              <CmdLink cmd={cmd} className="text-terminal-green font-normal">
-                {cmd}
-              </CmdLink>
-            </div>
+            <CmdLink key={cmd} cmd={cmd} className="text-terminal-green font-normal">
+              {cmd}
+            </CmdLink>
           ))}
         </div>
-      </div>,
+        <div className="pt-2 mt-2 border-t border-tui-accent-dim/30 text-xs text-tui-muted">
+          {commands.length} commands · try <CmdLink cmd="help" className="text-tui-accent-dim">help</CmdLink> for descriptions
+        </div>
+      </Block>,
+      'w-full',
     );
   }, [addNode, getAllCommandNames]);
 

--- a/client/src/hooks/useTerminal.tsx
+++ b/client/src/hooks/useTerminal.tsx
@@ -15,7 +15,9 @@ import { CollapsibleGroup, type CollapsibleItemData } from '../components/tui/Co
 import { ReplicatePage } from '../components/tui/ReplicatePage';
 import { LabeledRow, CompactRow } from '../components/tui/LabeledRow';
 import { MarkdownBlock } from '../components/tui/MarkdownBlock';
+import { BrailleSparkline, formatCompact } from '../components/tui/BrailleSparkline';
 import type { TerminalLinkRegistry, TerminalLink } from '../components/tui/LinkRegistry';
+import { loadPyPIStats, type PyPIStatsData } from '../lib/pypiStats';
 // Import specific date-fns functions for better tree-shaking
 import { parse } from 'date-fns/parse';
 
@@ -383,6 +385,7 @@ const COMMAND_REGISTRY: CommandMetadata[] = [
   { name: 'theme', description: 'Change terminal color theme', category: 'tools', argsHint: '[name]' },
   { name: 'gui', description: 'Switch to the GUI portfolio view', category: 'tools' },
   { name: 'replicate', description: 'Create your own terminal portfolio', category: 'tools', aliases: ['clone', 'fork'] },
+  { name: 'stats', description: 'Live PyPI download sparklines', category: 'tools' },
 
   // TERMINAL Commands (always available)
   { name: 'clear', description: 'Clear the terminal screen', category: 'terminal' },
@@ -2283,6 +2286,81 @@ export function useTerminal({ portfolioData, onSwitchToGUI }: UseTerminalProps) 
     );
   }, [addLine]);
 
+  const showStats = useCallback(async () => {
+    // Fetch the live pypi-stats.json; same source as the GUI hero.
+    let pypi: PyPIStatsData | null = null;
+    try {
+      pypi = await loadPyPIStats();
+    } catch {
+      pypi = null;
+    }
+
+    if (!pypi || Object.keys(pypi.packages).length === 0) {
+      addLine('stats: no pypi data available.', 'text-tui-error');
+      setLastExitCode(1);
+      return;
+    }
+
+    const packages = Object.values(pypi.packages);
+    // Sort by total downloads descending so the headline number leads.
+    packages.sort((a, b) => b.total_all_time - a.total_all_time);
+
+    const fetchedDate = pypi.fetched_at
+      ? new Date(pypi.fetched_at).toLocaleDateString('en-US', {
+          month: 'short',
+          day: 'numeric',
+          year: 'numeric',
+        })
+      : '';
+
+    addNode(
+      <Block title="// stats" wide>
+        <div className="mb-3 flex items-baseline gap-3 text-xs sm:text-sm font-mono">
+          <span className="text-tui-accent-dim">pypi</span>
+          <span className="text-terminal-bright-green text-lg tabular-nums">
+            {formatCompact(pypi.total_downloads)}
+          </span>
+          <span className="text-tui-muted text-xs">total downloads</span>
+          {fetchedDate && (
+            <span className="text-tui-muted/70 text-[10px] ml-auto">
+              as of {fetchedDate}
+            </span>
+          )}
+        </div>
+
+        <div className="text-tui-accent-dim text-xs mb-2">// packages</div>
+        <div className="space-y-1.5 font-mono text-xs">
+          {packages.map((pkg) => {
+            const weekly = pkg.weekly.map((w) => w.downloads);
+            const last = weekly[weekly.length - 1] ?? pkg.last_week;
+            return (
+              <div
+                key={pkg.name}
+                className="grid grid-cols-12 items-baseline gap-2 border-l-2 border-tui-accent-dim/40 pl-3"
+              >
+                <span className="col-span-4 sm:col-span-3 text-terminal-bright-green truncate">
+                  {pkg.name}
+                </span>
+                <span className="col-span-5 sm:col-span-6">
+                  <BrailleSparkline data={weekly} width={28} />
+                </span>
+                <span className="col-span-3 sm:col-span-3 text-right text-tui-muted tabular-nums">
+                  {formatCompact(last)}/wk
+                </span>
+              </div>
+            );
+          })}
+        </div>
+
+        <div className="mt-4 pt-3 border-t border-tui-accent-dim/30 text-xs text-tui-muted">
+          sparklines show weekly downloads for the last{' '}
+          {packages[0]?.weekly.length ?? 0} weeks. data refreshed daily.
+        </div>
+      </Block>,
+      'w-full',
+    );
+  }, [addLine, addNode]);
+
   const showKonami = useCallback(() => {
     // Reuse the GUI's cycleTheme helper so the flash affects both views.
     const next = cycleTheme();
@@ -2468,6 +2546,9 @@ export function useTerminal({ portfolioData, onSwitchToGUI }: UseTerminalProps) 
       case 'konami':
         showKonami();
         break;
+      case 'stats':
+        showStats();
+        break;
       default:
         // Check if this is a dynamic section command
         if (portfolioData?.cv?.sections) {
@@ -2487,7 +2568,7 @@ export function useTerminal({ portfolioData, onSwitchToGUI }: UseTerminalProps) 
         );
         setLastExitCode(127);
     }
-  }, [addLine, addNode, showHelp, openResumePdf, showWelcomeMessage, showAbout, showSkills, showExperience, showEducation, showProjects, showPersonalProjects, showContact, showPublications, showTimeline, showSearch, showTheme, showWhoAmI, listCommands, showCat, showNeofetch, showReplicate, showHistory, clearTerminal, showGenericSection, showQuote, showCoffee, showSudo, showMatrix, showKonami, portfolioData, onSwitchToGUI, currentDir]);
+  }, [addLine, addNode, showHelp, openResumePdf, showWelcomeMessage, showAbout, showSkills, showExperience, showEducation, showProjects, showPersonalProjects, showContact, showPublications, showTimeline, showSearch, showTheme, showWhoAmI, listCommands, showCat, showNeofetch, showReplicate, showHistory, clearTerminal, showGenericSection, showQuote, showCoffee, showSudo, showMatrix, showKonami, showStats, portfolioData, onSwitchToGUI, currentDir]);
 
   const navigateHistory = useCallback((direction: 'up' | 'down') => {
     if (commandHistory.length === 0) return currentInput;

--- a/client/src/hooks/useTerminal.tsx
+++ b/client/src/hooks/useTerminal.tsx
@@ -2,7 +2,7 @@ import { useState, useCallback, useEffect, useMemo, useRef, type ReactNode } fro
 import { type PortfolioData } from '../../../shared/schema';
 import { formatExperiencePeriod, getSocialNetworkUrl } from '../lib/portfolioData';
 import { themes } from '../lib/themes';
-import { colorThemes, applyColorTheme } from '../config/gui-theme.config';
+import { colorThemes, applyColorTheme, cycleTheme } from '../config/gui-theme.config';
 import { uiText, formatMessage, apiConfig, terminalConfig, derivePromptUser, storage, storageConfig } from '../config';
 import { renderCustomFields } from '../lib/fieldRenderer';
 import { inlineMd } from '../lib/tuiMarkdown';
@@ -299,7 +299,7 @@ async function getWelcomeNode(portfolioData: PortfolioData): Promise<ReactNode> 
 export interface CommandMetadata {
   name: string;
   description: string;
-  category: 'information' | 'professional' | 'contact' | 'tools' | 'terminal';
+  category: 'information' | 'professional' | 'contact' | 'tools' | 'terminal' | 'hidden';
   /**
    * Function to check if command should be available based on portfolio data
    * Returns true if command should be shown, false to hide it
@@ -309,6 +309,8 @@ export interface CommandMetadata {
   aliases?: string[];
   /** Hint for argument completion, e.g. `[term]` or `[theme-name]`. */
   argsHint?: string;
+  /** Hidden commands appear in autocomplete but not in `help`. */
+  hidden?: boolean;
 }
 
 const COMMAND_REGISTRY: CommandMetadata[] = [
@@ -384,6 +386,15 @@ const COMMAND_REGISTRY: CommandMetadata[] = [
   { name: 'ls', description: 'List available commands', category: 'terminal' },
   { name: 'pwd', description: 'Print working directory', category: 'terminal' },
   { name: 'cat', description: 'Display file contents', category: 'terminal', argsHint: '[file]' },
+
+  // HIDDEN Commands — autocomplete-discoverable, absent from `help`.
+  // Rewards for the curious; mirrors the GUI's select-to-reveal +
+  // long-press easter eggs.
+  { name: 'quote', description: 'Print a short quote', category: 'hidden', hidden: true },
+  { name: 'coffee', description: 'Brew a caffeinated ascii cup', category: 'hidden', hidden: true },
+  { name: 'sudo', description: 'A pleasant refusal', category: 'hidden', hidden: true, argsHint: '<anything>' },
+  { name: 'matrix', description: 'Trigger the idle screensaver on demand', category: 'hidden', hidden: true },
+  { name: 'konami', description: 'Cycle color theme with a flash', category: 'hidden', hidden: true },
 ];
 
 export function useTerminal({ portfolioData, onSwitchToGUI }: UseTerminalProps) {
@@ -545,7 +556,11 @@ export function useTerminal({ portfolioData, onSwitchToGUI }: UseTerminalProps) 
       terminal: [],
     };
     availableCommands.forEach((cmd) => {
-      commandsByCategory[cmd.category].push(cmd);
+      // Hidden commands are discoverable via autocomplete only.
+      if (cmd.hidden) return;
+      if (commandsByCategory[cmd.category]) {
+        commandsByCategory[cmd.category].push(cmd);
+      }
     });
 
     const categoryConfig = {
@@ -2183,8 +2198,123 @@ export function useTerminal({ portfolioData, onSwitchToGUI }: UseTerminalProps) 
     );
   }, [addLine, addNode, commandHistory]);
 
+  // ── Hidden-command handlers (phase 9 easter eggs) ──
+
+  const QUOTES = [
+    'the best way to predict the future is to implement it.',
+    'simplicity is the soul of efficiency.',
+    'a user interface is like a joke — if you have to explain it, it\'s not that good.',
+    'programs must be written for people to read, and only incidentally for machines to execute.',
+    'the computer was born to solve problems that did not exist before.',
+    'first, solve the problem. then, write the code.',
+    'debugging is twice as hard as writing the code in the first place.',
+    'code is read far more often than it is written.',
+    'make it work, make it right, make it fast.',
+    'there are only two hard things in computer science: cache invalidation, naming things, and off-by-one errors.',
+  ];
+
+  const showQuote = useCallback(() => {
+    const q = QUOTES[Math.floor(Math.random() * QUOTES.length)];
+    addNode(
+      <Block title="// quote">
+        <div className="border-l-2 border-tui-accent-dim/60 pl-3 italic text-white/90 leading-relaxed">
+          {q}
+        </div>
+      </Block>,
+      'w-full',
+    );
+  }, [addNode]);
+
+  const showCoffee = useCallback(() => {
+    // Hidden ASCII cup — emoji is ok here because it's a deliberate
+    // easter egg moment, not decorative chrome.
+    addNode(
+      <Block title="// coffee">
+        <pre className="text-terminal-bright-green text-xs leading-tight whitespace-pre font-mono">{`
+      ( (
+       ) )
+    ........
+    |      |]
+    \\      /
+     \`----'`}</pre>
+        <div className="text-white/80 text-xs mt-2">
+          ☕ thanks for visiting. caffeine sent telepathically.
+        </div>
+      </Block>,
+      'w-full',
+    );
+  }, [addNode]);
+
+  const showSudo = useCallback((args: string[]) => {
+    const sub = args.join(' ').trim();
+    if (!sub) {
+      addLine('usage: sudo <command>', 'text-tui-muted');
+      return;
+    }
+    if (/rm\s+-r?f?\s*\/?/i.test(sub)) {
+      addLine('nice try. this is a portfolio, not your filesystem.', 'text-tui-accent-dim');
+      return;
+    }
+    if (/shutdown|reboot|halt/i.test(sub)) {
+      addLine('i would if i could.', 'text-tui-accent-dim');
+      return;
+    }
+    addLine(
+      `[sudo] password for visitor: ········`,
+      'text-tui-muted',
+    );
+    addLine('sorry, no sudo for you.', 'text-tui-accent-dim');
+  }, [addLine]);
+
+  const showMatrix = useCallback(() => {
+    // Phase 12 wires an actual matrix-rain overlay into the output
+    // pane. Until then, print a quick reminder.
+    addLine(
+      'matrix screensaver: idle for 30s or wait for phase 12 wiring.',
+      'text-tui-accent-dim',
+    );
+  }, [addLine]);
+
+  const showKonami = useCallback(() => {
+    // Reuse the GUI's cycleTheme helper so the flash affects both views.
+    const next = cycleTheme();
+    addLine(`// theme → ${next.name.toLowerCase()}`, 'text-terminal-bright-green');
+  }, [addLine]);
+
   const executeCommand = useCallback((command: string) => {
     if (!command.trim()) return;
+
+    // Vim-style `:cmd args` aliases. Normalise `:q` → `gui`, `:wq` →
+    // an easter-egg flourish, `:theme x` → `theme x`, etc. This runs
+    // before the command echo so the scrollback shows the canonical
+    // form the handler actually ran.
+    let normalised = command.trim();
+    if (normalised.startsWith(':')) {
+      const raw = normalised.slice(1).trim().toLowerCase();
+      if (raw === 'q' || raw === 'quit') {
+        normalised = 'gui';
+      } else if (raw === 'wq') {
+        // Shell out to gui after the flourish — the echo line shows :wq,
+        // then the gui command executes.
+        addLine('nothing to save. you\'re a read-only visitor here.', 'text-tui-accent-dim');
+        normalised = 'gui';
+      } else if (raw === 'help' || raw === 'h') {
+        normalised = 'help';
+      } else if (raw === 'clear' || raw === 'cls') {
+        normalised = 'clear';
+      } else if (raw.startsWith('theme')) {
+        normalised = raw;
+      } else if (raw === 'palette' || raw === 'k') {
+        // `:palette` / `:k` would open the command palette — handled at
+        // the Terminal level via Ctrl+K. Print a nudge here.
+        addLine('press ⌃K to open the command palette.', 'text-tui-muted');
+        return;
+      } else {
+        // Unknown colon shortcut — fall through to treat as regular cmd.
+        normalised = raw;
+      }
+    }
+    const effectiveCommand = normalised;
 
     // Derive user slug from cv.name so the echoed line matches the
     // live prompt. Falls back to 'guest' if data isn't loaded yet.
@@ -2198,7 +2328,9 @@ export function useTerminal({ portfolioData, onSwitchToGUI }: UseTerminalProps) 
     });
     setHistoryIndex(-1);
 
-    const args = command.trim().split(' ');
+    // `args` + `cmd` are parsed from the :-normalised string — that's
+    // what handlers actually see and route on.
+    const args = effectiveCommand.trim().split(' ');
     const cmd = args[0].toLowerCase();
 
     // Check if command is available (exists in registry and passes availability check)
@@ -2313,6 +2445,21 @@ export function useTerminal({ portfolioData, onSwitchToGUI }: UseTerminalProps) 
       case 'history':
         showHistory(args.slice(1));
         break;
+      case 'quote':
+        showQuote();
+        break;
+      case 'coffee':
+        showCoffee();
+        break;
+      case 'sudo':
+        showSudo(args.slice(1));
+        break;
+      case 'matrix':
+        showMatrix();
+        break;
+      case 'konami':
+        showKonami();
+        break;
       default:
         // Check if this is a dynamic section command
         if (portfolioData?.cv?.sections) {
@@ -2323,15 +2470,16 @@ export function useTerminal({ portfolioData, onSwitchToGUI }: UseTerminalProps) 
           }
         }
         // Command not found
-        addLine(formatMessage(uiText.messages.error.commandNotFound, { cmd }), 'text-terminal-red');
+        addLine(formatMessage(uiText.messages.error.commandNotFound, { cmd }), 'text-tui-error');
         addNode(
-          <span className="text-terminal-yellow">
-            Type <code className="font-mono"><CmdLink cmd="help" className="text-terminal-yellow">help</CmdLink></code>{' '}
-            or click on a command above to get started.
+          <span className="text-tui-accent-dim text-xs">
+            type <CmdLink cmd="help">help</CmdLink>{' '}
+            or click a command to get started.
           </span>,
         );
+        setLastExitCode(127);
     }
-  }, [addLine, addNode, showHelp, openResumePdf, showWelcomeMessage, showAbout, showSkills, showExperience, showEducation, showProjects, showPersonalProjects, showContact, showPublications, showTimeline, showSearch, showTheme, showWhoAmI, listCommands, showCat, showNeofetch, showReplicate, showHistory, clearTerminal, showGenericSection, portfolioData, onSwitchToGUI, currentDir]);
+  }, [addLine, addNode, showHelp, openResumePdf, showWelcomeMessage, showAbout, showSkills, showExperience, showEducation, showProjects, showPersonalProjects, showContact, showPublications, showTimeline, showSearch, showTheme, showWhoAmI, listCommands, showCat, showNeofetch, showReplicate, showHistory, clearTerminal, showGenericSection, showQuote, showCoffee, showSudo, showMatrix, showKonami, portfolioData, onSwitchToGUI, currentDir]);
 
   const navigateHistory = useCallback((direction: 'up' | 'down') => {
     if (commandHistory.length === 0) return currentInput;

--- a/client/src/hooks/useTerminal.tsx
+++ b/client/src/hooks/useTerminal.tsx
@@ -16,7 +16,7 @@ import { LabeledRow, CompactRow } from '../components/tui/LabeledRow';
 import { MarkdownBlock } from '../components/tui/MarkdownBlock';
 import { BrailleSparkline, formatCompact } from '../components/tui/BrailleSparkline';
 import type { TerminalLinkRegistry, TerminalLink } from '../components/tui/LinkRegistry';
-import { loadPyPIStats, type PyPIStatsData } from '../lib/pypiStats';
+import { loadPyPIStats, type PyPIStatsData, type PyPIPackageStats } from '../lib/pypiStats';
 // Import specific date-fns functions for better tree-shaking
 import { parse } from 'date-fns/parse';
 
@@ -100,6 +100,65 @@ const formatDateForDisplay = (dateStr: string): string => {
     month: 'short' 
   });
 };
+
+/** Synthesise a demo PyPI stats payload so the `stats` command always
+ *  has something to render when the real `pypi-stats.json` is missing
+ *  (template clones, pre-deploy, offline dev). Values are obviously
+ *  fake — the UI flags this with a "· demo data" tag. */
+function buildDemoPypi(): PyPIStatsData {
+  const today = new Date();
+  const weeklyFor = (baseDownloads: number, jitter: number, weeks = 16) =>
+    Array.from({ length: weeks }, (_, i) => {
+      const d = new Date(today);
+      d.setDate(d.getDate() - (weeks - i) * 7);
+      const phase = Math.sin((i / weeks) * Math.PI * 2.2);
+      const noise = (Math.random() - 0.5) * jitter;
+      const value = Math.max(0, Math.round(baseDownloads * (1 + 0.35 * phase) + noise));
+      return { date: d.toISOString().slice(0, 10), downloads: value };
+    });
+
+  const demoPackages: Record<string, PyPIPackageStats> = {
+    quickstart: {
+      name: 'quickstart',
+      total_all_time: 32100,
+      total_180d: 9200,
+      last_day: 220,
+      last_week: 1480,
+      last_month: 5400,
+      daily: [],
+      weekly: weeklyFor(1200, 600),
+    },
+    sqlstream: {
+      name: 'sqlstream',
+      total_all_time: 5200,
+      total_180d: 1800,
+      last_day: 42,
+      last_week: 290,
+      last_month: 980,
+      daily: [],
+      weekly: weeklyFor(260, 140),
+    },
+    'smart-commit': {
+      name: 'smart-commit',
+      total_all_time: 3400,
+      total_180d: 1100,
+      last_day: 18,
+      last_week: 160,
+      last_month: 520,
+      daily: [],
+      weekly: weeklyFor(140, 90),
+    },
+  };
+  const total = Object.values(demoPackages).reduce(
+    (s, p) => s + p.total_all_time,
+    0,
+  );
+  return {
+    fetched_at: today.toISOString(),
+    total_downloads: total,
+    packages: demoPackages,
+  };
+}
 
 function getProjectsNode(
   projectData: Array<Record<string, unknown>>,
@@ -220,7 +279,7 @@ async function getWelcomeNode(portfolioData: PortfolioData): Promise<ReactNode> 
       </div>
 
       <SectionBox
-        title="QUICK OVERVIEW"
+        title="// overview"
         bodyClassName="p-3 space-y-1 text-xs sm:text-sm"
         className="max-w-none"
       >
@@ -230,43 +289,23 @@ async function getWelcomeNode(portfolioData: PortfolioData): Promise<ReactNode> 
         {cv.website && (
           <CompactRow
             label="WEB"
-            value={<span className="text-terminal-green">{cv.website}</span>}
+            value={<ExtLink href={cv.website}>{cv.website.replace(/^https?:\/\//, '')}</ExtLink>}
           />
         )}
         <CompactRow
           label="EMAIL"
-          value={<span className="text-terminal-green">{cv.email}</span>}
+          value={<ExtLink href={`mailto:${cv.email}`}>{cv.email}</ExtLink>}
         />
         {cv.resume_url && (
           <CompactRow
             label="RESUME"
-            value={
-              <span className="text-terminal-green">
-                <a
-                  href={cv.resume_url}
-                  target="_blank"
-                  rel="noopener noreferrer"
-                  className="text-terminal-bright-green hover:text-terminal-yellow hover:underline cursor-pointer"
-                >
-                  resume.pdf
-                </a>
-              </span>
-            }
+            value={<ExtLink href={cv.resume_url}>resume.pdf</ExtLink>}
           />
         )}
         {sanitizedPhone && (
           <CompactRow
             label="PHONE"
-            value={
-              <span className="text-terminal-green">
-                <a
-                  href={`tel:${sanitizedPhone}`}
-                  className="text-terminal-bright-green hover:text-terminal-yellow hover:underline cursor-pointer"
-                >
-                  {sanitizedPhone}
-                </a>
-              </span>
-            }
+            value={<ExtLink href={`tel:${sanitizedPhone}`}>{sanitizedPhone}</ExtLink>}
           />
         )}
       </SectionBox>
@@ -404,6 +443,9 @@ const COMMAND_REGISTRY: CommandMetadata[] = [
   { name: 'sudo', description: 'A pleasant refusal', category: 'hidden', hidden: true, argsHint: '<anything>' },
   { name: 'matrix', description: 'Trigger the idle screensaver on demand', category: 'hidden', hidden: true },
   { name: 'konami', description: 'Cycle color theme with a flash', category: 'hidden', hidden: true },
+  // `o N` / `g N` — vim-motion link open. The handler reads the
+  // argument number and opens the corresponding registered link.
+  { name: 'open', description: 'Open link by number', category: 'tools', hidden: true, aliases: ['o', 'g'], argsHint: '<N>' },
 ];
 
 export function useTerminal({ portfolioData, onSwitchToGUI, onTriggerMatrix }: UseTerminalProps) {
@@ -623,7 +665,7 @@ export function useTerminal({ portfolioData, onSwitchToGUI, onTriggerMatrix }: U
 
     addNode(
       <SectionBox
-        title="AVAILABLE COMMANDS"
+        title="// help"
         centerTitle
         bodyClassName="p-3 space-y-3 text-xs sm:text-sm"
       >
@@ -705,8 +747,7 @@ export function useTerminal({ portfolioData, onSwitchToGUI, onTriggerMatrix }: U
 
     addNode(
       <SectionBox
-        title="ABOUT ME"
-        centerTitle
+        title="// about"
         bodyClassName="p-3 space-y-3 text-xs sm:text-sm"
       >
         <div>
@@ -724,39 +765,23 @@ export function useTerminal({ portfolioData, onSwitchToGUI, onTriggerMatrix }: U
           <div className="space-y-1 ml-1">
             {cv.website ? (
               <LabeledRow label="Portfolio">
-                <a href={cv.website} className="hover:text-terminal-bright-green">
+                <ExtLink href={cv.website}>
                   {cv.website.replace('https://', '').trim()}
-                </a>{' '}
-                (you are here)
+                </ExtLink>{' '}
+                <span className="text-tui-muted">(you are here)</span>
               </LabeledRow>
             ) : null}
             <LabeledRow label="Email">
-              <a href={`mailto:${cv.email}`} className="hover:text-terminal-bright-green">
-                {cv.email}
-              </a>
+              <ExtLink href={`mailto:${cv.email}`}>{cv.email}</ExtLink>
             </LabeledRow>
             {gh && (
               <LabeledRow label="GitHub">
-                <a
-                  href={`https://github.com/${gh}`}
-                  target="_blank"
-                  rel="noopener noreferrer"
-                  className="hover:text-terminal-bright-green"
-                >
-                  {gh}
-                </a>
+                <ExtLink href={`https://github.com/${gh}`}>{gh}</ExtLink>
               </LabeledRow>
             )}
             {li && (
               <LabeledRow label="LinkedIn">
-                <a
-                  href={`https://linkedin.com/in/${li}`}
-                  target="_blank"
-                  rel="noopener noreferrer"
-                  className="hover:text-terminal-bright-green"
-                >
-                  {li}
-                </a>
+                <ExtLink href={`https://linkedin.com/in/${li}`}>{li}</ExtLink>
               </LabeledRow>
             )}
           </div>
@@ -945,7 +970,7 @@ export function useTerminal({ portfolioData, onSwitchToGUI, onTriggerMatrix }: U
     const techs = portfolioData.cv.sections?.technologies ?? [];
     addNode(
       <SectionBox
-        title="SKILLS & TECHNOLOGIES"
+        title="// skills"
         centerTitle
         bodyClassName="p-3 space-y-3 text-xs sm:text-sm"
       >
@@ -985,7 +1010,7 @@ export function useTerminal({ portfolioData, onSwitchToGUI, onTriggerMatrix }: U
     const jobs = portfolioData.cv.sections?.experience ?? [];
     addNode(
       <SectionBox
-        title="PROFESSIONAL EXPERIENCE"
+        title="// experience"
         centerTitle
         bodyClassName="p-3 space-y-4 text-xs sm:text-sm"
       >
@@ -1054,7 +1079,7 @@ export function useTerminal({ portfolioData, onSwitchToGUI, onTriggerMatrix }: U
     const edus = portfolioData.cv.sections?.education ?? [];
     addNode(
       <SectionBox
-        title="EDUCATION"
+        title="// education"
         centerTitle
         bodyClassName="p-3 space-y-4 text-xs sm:text-sm"
       >
@@ -1167,7 +1192,7 @@ export function useTerminal({ portfolioData, onSwitchToGUI, onTriggerMatrix }: U
 
     addNode(
       <SectionBox
-        title="RESEARCH PUBLICATIONS"
+        title="// publications"
         centerTitle
         bodyClassName="p-3 space-y-4 text-xs sm:text-sm"
       >
@@ -1190,14 +1215,9 @@ export function useTerminal({ portfolioData, onSwitchToGUI, onTriggerMatrix }: U
                     <MetaRow
                       label="DOI"
                       value={
-                        <a
-                          href={`https://doi.org/${pub.doi}`}
-                          target="_blank"
-                          rel="noopener noreferrer"
-                          className="hover:text-terminal-bright-green underline"
-                        >
+                        <ExtLink href={`https://doi.org/${pub.doi}`}>
                           https://doi.org/{pub.doi}
-                        </a>
+                        </ExtLink>
                       }
                     />
                   )}
@@ -1363,16 +1383,19 @@ export function useTerminal({ portfolioData, onSwitchToGUI, onTriggerMatrix }: U
                 : formatDateForDisplay(event.dateStr);
               return (
                 <div key={index} className="relative flex items-start space-x-4 group">
-                  <div className="relative z-10 pt-1">
+                  <div className="relative z-10 pt-[5px]">
+                    {/* Small diamond marker — avoids the "checkbox" read
+                        of the previous outlined square. */}
                     <div
-                      className={`w-3 h-3 bg-terminal-black border border-terminal-bright-green ${isOngoing ? 'animate-pulse shadow-[0_0_8px_rgba(var(--glow-color-rgb),0.6)]' : ''}`}
+                      aria-hidden="true"
+                      className={`w-2 h-2 rotate-45 bg-terminal-bright-green ${isOngoing ? 'animate-pulse shadow-[0_0_8px_rgba(var(--glow-color-rgb),0.7)]' : 'opacity-80'}`}
                     />
                   </div>
 
                   <div className="flex-1 min-w-0 pb-2">
                     <div className="border-l-2 border-tui-accent-dim/40 pl-3 group-hover:border-terminal-bright-green transition-colors duration-150">
                       <div className="flex flex-wrap items-baseline gap-x-2 gap-y-0.5 mb-1 text-xs font-mono">
-                        <span className={`${getTypeColor(event.type)} uppercase tracking-wide`}>
+                        <span className={`${getTypeColor(event.type)} tracking-wide`}>
                           {getTypeLabel(event.type).toLowerCase()}
                         </span>
                         {isOngoing && (
@@ -1551,7 +1574,7 @@ export function useTerminal({ portfolioData, onSwitchToGUI, onTriggerMatrix }: U
     };
 
     addNode(
-      <SectionBox title="SEARCH RESULTS" centerTitle>
+      <SectionBox title="// search results">
         <div className="bg-terminal-green/5 p-2 rounded flex flex-wrap gap-x-3 gap-y-1">
           <span>
             <span className="text-terminal-yellow font-semibold">Search term:</span>
@@ -1611,7 +1634,7 @@ export function useTerminal({ portfolioData, onSwitchToGUI, onTriggerMatrix }: U
 
     if (!theme) {
       addNode(
-        <SectionBox title="AVAILABLE THEMES" bodyClassName="p-3 space-y-1 text-xs sm:text-sm">
+        <SectionBox title="// themes" bodyClassName="p-3 space-y-1 text-xs sm:text-sm">
           {colorThemes.map((t) => {
             const [r, g, b] = t.accentRgb;
             return (
@@ -1641,7 +1664,7 @@ export function useTerminal({ portfolioData, onSwitchToGUI, onTriggerMatrix }: U
       storage.remove(storageConfig.keys.theme);
       localStorage.removeItem('gui-color-theme');
       applyColorTheme(colorThemes[0]);
-      addLine('Theme reset.', 'text-terminal-yellow');
+      addLine('// theme → reset', 'text-tui-accent-dim');
       return;
     }
 
@@ -1655,11 +1678,11 @@ export function useTerminal({ portfolioData, onSwitchToGUI, onTriggerMatrix }: U
     if (matchedTheme && themes[matchedTheme.key]) {
       const selectedTheme = themes[matchedTheme.key];
       applyColorTheme(matchedTheme);
-      addLine(`Switched to ${selectedTheme.name}.`, 'text-terminal-bright-green');
+      addLine(`// theme → ${selectedTheme.name.toLowerCase()}`, 'text-terminal-bright-green');
     } else {
       addLine(
-        'Theme not found. Use "theme" to see available themes.',
-        'text-terminal-red',
+        'theme not found. run `theme` to list available.',
+        'text-tui-error',
       );
     }
   }, [addLine, addNode]);
@@ -1677,7 +1700,7 @@ export function useTerminal({ portfolioData, onSwitchToGUI, onTriggerMatrix }: U
 
     addNode(
       <SectionBox
-        title="CONTACT INFORMATION"
+        title="// contact"
         centerTitle
         bodyClassName="p-3 space-y-3 text-xs sm:text-sm"
       >
@@ -1691,12 +1714,7 @@ export function useTerminal({ portfolioData, onSwitchToGUI, onTriggerMatrix }: U
               label="Phone"
               value={
                 cv.phone ? (
-                  <a
-                    href={cv.phone}
-                    className="text-terminal-bright-green hover:text-terminal-yellow cursor-pointer"
-                  >
-                    {cv.phone.replace(/[^\d+]/g, '')}
-                  </a>
+                  <ExtLink href={cv.phone}>{cv.phone.replace(/[^\d+]/g, '')}</ExtLink>
                 ) : (
                   ''
                 )
@@ -1707,13 +1725,16 @@ export function useTerminal({ portfolioData, onSwitchToGUI, onTriggerMatrix }: U
         <div>
           <div className="text-tui-accent-dim text-xs mb-2">// social</div>
           <div className="space-y-1 ml-1">
-            {cv.social_networks?.map((social) => (
-              <Row
-                key={social.network}
-                label={social.network}
-                value={getSocialNetworkUrl(social.network, social.username)}
-              />
-            ))}
+            {cv.social_networks?.map((social) => {
+              const url = getSocialNetworkUrl(social.network, social.username);
+              return (
+                <Row
+                  key={social.network}
+                  label={social.network}
+                  value={<ExtLink href={url}>{social.username}</ExtLink>}
+                />
+              );
+            })}
           </div>
         </div>
         <div className="border-t border-tui-accent-dim/30 pt-3">
@@ -2163,7 +2184,7 @@ export function useTerminal({ portfolioData, onSwitchToGUI, onTriggerMatrix }: U
 
     if (commandHistory.length === 0) {
       addNode(
-        <SectionBox title="COMMAND HISTORY" centerTitle>
+        <SectionBox title="// history">
           <div className="text-terminal-yellow">No commands in history yet.</div>
           <div className="text-white/70 text-xs">
             Commands you run are saved to local storage; they'll show up here.
@@ -2181,7 +2202,7 @@ export function useTerminal({ portfolioData, onSwitchToGUI, onTriggerMatrix }: U
 
     addNode(
       <SectionBox
-        title="COMMAND HISTORY"
+        title="// history"
         centerTitle
         bodyClassName="p-3 space-y-0.5 text-xs sm:text-sm font-mono"
       >
@@ -2300,18 +2321,21 @@ export function useTerminal({ portfolioData, onSwitchToGUI, onTriggerMatrix }: U
       pypi = null;
     }
 
-    if (!pypi || Object.keys(pypi.packages).length === 0) {
-      addLine('stats: no pypi data available.', 'text-tui-error');
-      setLastExitCode(1);
-      return;
+    // Fall back to a synthesized demo series if the stats file is
+    // missing (pre-deploy / template clones / first-run). The sparkline
+    // command should always demo SOMETHING — a useful feature shouldn't
+    // silently vanish when real data isn't around.
+    const isDemo = !pypi || Object.keys(pypi.packages).length === 0;
+    if (isDemo) {
+      pypi = buildDemoPypi();
     }
 
-    const packages = Object.values(pypi.packages);
+    const packages = Object.values(pypi!.packages);
     // Sort by total downloads descending so the headline number leads.
     packages.sort((a, b) => b.total_all_time - a.total_all_time);
 
-    const fetchedDate = pypi.fetched_at
-      ? new Date(pypi.fetched_at).toLocaleDateString('en-US', {
+    const fetchedDate = pypi!.fetched_at
+      ? new Date(pypi!.fetched_at).toLocaleDateString('en-US', {
           month: 'short',
           day: 'numeric',
           year: 'numeric',
@@ -2323,9 +2347,14 @@ export function useTerminal({ portfolioData, onSwitchToGUI, onTriggerMatrix }: U
         <div className="mb-3 flex items-baseline gap-3 text-xs sm:text-sm font-mono">
           <span className="text-tui-accent-dim">pypi</span>
           <span className="text-terminal-bright-green text-lg tabular-nums">
-            {formatCompact(pypi.total_downloads)}
+            {formatCompact(pypi!.total_downloads)}
           </span>
           <span className="text-tui-muted text-xs">total downloads</span>
+          {isDemo && (
+            <span className="text-tui-warn/80 text-[10px] uppercase tracking-wide">
+              · demo data
+            </span>
+          )}
           {fetchedDate && (
             <span className="text-tui-muted/70 text-[10px] ml-auto">
               as of {fetchedDate}
@@ -2554,6 +2583,25 @@ export function useTerminal({ portfolioData, onSwitchToGUI, onTriggerMatrix }: U
       case 'stats':
         showStats();
         break;
+      case 'open':
+      case 'o':
+      case 'g': {
+        const n = parseInt(args[1] ?? '', 10);
+        if (Number.isNaN(n)) {
+          addLine('usage: o <N>  — open link number N in view', 'text-tui-muted');
+          setLastExitCode(1);
+          break;
+        }
+        const link = linkRegistry.resolve(n);
+        if (link) {
+          window.open(link.href, '_blank', 'noopener,noreferrer');
+          addLine(`→ opening ${link.label}`, 'text-tui-accent-dim');
+        } else {
+          addLine(`no link #${n} in view`, 'text-tui-error');
+          setLastExitCode(1);
+        }
+        break;
+      }
       default:
         // Check if this is a dynamic section command
         if (portfolioData?.cv?.sections) {
@@ -2573,7 +2621,7 @@ export function useTerminal({ portfolioData, onSwitchToGUI, onTriggerMatrix }: U
         );
         setLastExitCode(127);
     }
-  }, [addLine, addNode, showHelp, openResumePdf, showWelcomeMessage, showAbout, showSkills, showExperience, showEducation, showProjects, showPersonalProjects, showContact, showPublications, showTimeline, showSearch, showTheme, showWhoAmI, listCommands, showCat, showNeofetch, showReplicate, showHistory, clearTerminal, showGenericSection, showQuote, showCoffee, showSudo, showMatrix, showKonami, showStats, portfolioData, onSwitchToGUI, currentDir]);
+  }, [addLine, addNode, showHelp, openResumePdf, showWelcomeMessage, showAbout, showSkills, showExperience, showEducation, showProjects, showPersonalProjects, showContact, showPublications, showTimeline, showSearch, showTheme, showWhoAmI, listCommands, showCat, showNeofetch, showReplicate, showHistory, clearTerminal, showGenericSection, showQuote, showCoffee, showSudo, showMatrix, showKonami, showStats, linkRegistry, portfolioData, onSwitchToGUI, currentDir]);
 
   const navigateHistory = useCallback((direction: 'up' | 'down') => {
     if (commandHistory.length === 0) return currentInput;

--- a/client/src/hooks/useTerminal.tsx
+++ b/client/src/hooks/useTerminal.tsx
@@ -2351,5 +2351,7 @@ export function useTerminal({ portfolioData, onSwitchToGUI }: UseTerminalProps) 
     lastExitCode,
     promptUser,
     promptHost: terminalConfig.prompt.hostname,
+    // Used by the status bar to render live counts.
+    historyLength: commandHistory.length,
   };
 }

--- a/client/src/hooks/useTerminal.tsx
+++ b/client/src/hooks/useTerminal.tsx
@@ -34,6 +34,9 @@ export interface TerminalLine {
 export interface UseTerminalProps {
   portfolioData: PortfolioData | null;
   onSwitchToGUI?: () => void;
+  /** Called by the `matrix` command to trigger the idle-rain overlay
+   *  on demand. Terminal.tsx wires this to setMatrixActive(true). */
+  onTriggerMatrix?: () => void;
 }
 
 function getUsername(portfolioData: PortfolioData, network: string): string | undefined {
@@ -404,7 +407,7 @@ const COMMAND_REGISTRY: CommandMetadata[] = [
   { name: 'konami', description: 'Cycle color theme with a flash', category: 'hidden', hidden: true },
 ];
 
-export function useTerminal({ portfolioData, onSwitchToGUI }: UseTerminalProps) {
+export function useTerminal({ portfolioData, onSwitchToGUI, onTriggerMatrix }: UseTerminalProps) {
   const [lines, setLines] = useState<TerminalLine[]>([]);
   const [commandHistory, setCommandHistory] = useState<string[]>(() => {
     // Rehydrate from localStorage so the history command + arrow-key
@@ -2278,13 +2281,16 @@ export function useTerminal({ portfolioData, onSwitchToGUI }: UseTerminalProps) 
   }, [addLine]);
 
   const showMatrix = useCallback(() => {
-    // Phase 12 wires an actual matrix-rain overlay into the output
-    // pane. Until then, print a quick reminder.
-    addLine(
-      'matrix screensaver: idle for 30s or wait for phase 12 wiring.',
-      'text-tui-accent-dim',
-    );
-  }, [addLine]);
+    if (onTriggerMatrix) {
+      addLine('// matrix — rain summoned. any key dismisses.', 'text-terminal-bright-green');
+      onTriggerMatrix();
+    } else {
+      addLine(
+        'matrix screensaver: idle for 30s to see it.',
+        'text-tui-accent-dim',
+      );
+    }
+  }, [addLine, onTriggerMatrix]);
 
   const showStats = useCallback(async () => {
     // Fetch the live pypi-stats.json; same source as the GUI hero.

--- a/client/src/hooks/useTerminal.tsx
+++ b/client/src/hooks/useTerminal.tsx
@@ -203,7 +203,7 @@ async function getWelcomeNode(portfolioData: PortfolioData): Promise<ReactNode> 
         )}
       </div>
       <div className="mb-4">
-        <p className="text-terminal-green mb-2 text-sm sm:text-base">Welcome to my portfolio!</p>
+        <p className="text-terminal-green mb-2 text-sm sm:text-base">{uiText.welcome.greeting}</p>
         <p
           className="text-white/80 mb-2 text-xs sm:text-sm leading-relaxed"
           dangerouslySetInnerHTML={{ __html: inlineMd(introParagraph) }}
@@ -263,39 +263,31 @@ async function getWelcomeNode(portfolioData: PortfolioData): Promise<ReactNode> 
       </SectionBox>
 
       <div className="mb-4">
-        <p className="text-terminal-green mb-2 text-sm sm:text-base">
-          🚀 Start exploring with these core commands (or click them):
+        <p className="text-tui-accent-dim mb-2 text-xs sm:text-sm">
+          // quick tiles
         </p>
         <div className="grid grid-cols-1 sm:grid-cols-2 gap-2 text-xs sm:text-sm">
-          <QuickCmd cmd="about" label="learn more about me" />
-          <QuickCmd cmd="skills" label="view technical expertise" />
-          <QuickCmd cmd="experience" label="see professional work" />
-          <QuickCmd cmd="projects" label="see professional projects" />
-          <QuickCmd cmd="personal" label="see personal projects" />
-          <QuickCmd cmd="contact" label="display contact details" />
+          <QuickCmd cmd="about" label="background" />
+          <QuickCmd cmd="skills" label="technical expertise" />
+          <QuickCmd cmd="experience" label="work history" />
+          <QuickCmd cmd="projects" label="professional work" />
+          <QuickCmd cmd="personal" label="personal projects" />
+          <QuickCmd cmd="contact" label="get in touch" />
         </div>
       </div>
 
-      <div className="text-xs sm:text-sm space-y-2">
-        <div className="flex items-center space-x-2 text-terminal-green/80">
-          <span>💡</span>
-          <span>
-            Type{' '}
-            <CmdLink cmd="help" className="font-bold hover:text-terminal-yellow">
-              help
-            </CmdLink>{' '}
-            for all commands
-          </span>
+      <div className="text-xs space-y-1 text-tui-muted">
+        <div>
+          type{' '}
+          <CmdLink cmd="help">help</CmdLink>{' '}
+          for all commands
         </div>
-        <div className="flex items-center space-x-2 text-terminal-green/40 text-xs">
-          <span>✨</span>
-          <span>
-            Like this portfolio? Type{' '}
-            <CmdLink cmd="replicate" className="text-terminal-green/60 hover:text-terminal-green">
-              replicate
-            </CmdLink>{' '}
-            to create your own in ~5 min
-          </span>
+        <div className="text-tui-muted/70">
+          like this portfolio? type{' '}
+          <CmdLink cmd="replicate" className="text-tui-muted">
+            replicate
+          </CmdLink>{' '}
+          to fork it in ~5 min
         </div>
       </div>
     </div>
@@ -507,11 +499,11 @@ export function useTerminal({ portfolioData, onSwitchToGUI }: UseTerminalProps) 
     });
 
     const categoryConfig = {
-      information: { emoji: '📋', label: 'INFORMATION' },
-      professional: { emoji: '💼', label: 'PROFESSIONAL' },
-      contact: { emoji: '📧', label: 'CONTACT' },
-      tools: { emoji: '🔧', label: 'TOOLS' },
-      terminal: { emoji: '⌨️', label: 'TERMINAL' },
+      information: { label: 'information' },
+      professional: { label: 'professional' },
+      contact: { label: 'contact' },
+      tools: { label: 'tools' },
+      terminal: { label: 'terminal' },
     } as const;
 
     const CommandRow = ({ cmd }: { cmd: CommandMetadata }) => {
@@ -540,11 +532,11 @@ export function useTerminal({ portfolioData, onSwitchToGUI }: UseTerminalProps) 
     const Category = ({ cat }: { cat: keyof typeof categoryConfig }) => {
       const cmds = commandsByCategory[cat];
       if (!cmds.length) return null;
-      const { emoji, label } = categoryConfig[cat];
+      const { label } = categoryConfig[cat];
       return (
         <div>
-          <div className="text-terminal-bright-green font-bold mb-2">
-            {emoji} {label}
+          <div className="text-tui-accent-dim text-xs mb-2">
+            // {label}
           </div>
           <div className="space-y-1 ml-2">
             {cmds.map((cmd) => (
@@ -566,39 +558,34 @@ export function useTerminal({ portfolioData, onSwitchToGUI }: UseTerminalProps) 
         <Category cat="contact" />
         <Category cat="tools" />
         <Category cat="terminal" />
-        <div className="border-t border-terminal-green/30 pt-3">
-          <div className="text-terminal-yellow font-bold mb-2">💡 EXPLORE MORE</div>
-          <div className="space-y-1 ml-2 text-xs">
+        <div className="border-t border-tui-accent-dim/30 pt-3">
+          <div className="text-tui-accent-dim text-xs mb-2">// tips</div>
+          <div className="space-y-0.5 ml-1 text-xs text-white/80">
             <div>
-              <span className="text-white">• </span>Use{' '}
-              <span className="text-terminal-bright-green font-semibold">Tab</span> for
-              auto-completion
+              <span className="text-tui-accent-dim">· </span>
+              <span className="text-terminal-bright-green font-mono">tab</span> for auto-completion
             </div>
             <div>
-              <span className="text-white">• </span>Use{' '}
-              <span className="text-terminal-bright-green font-semibold">↑↓</span> arrow keys to
-              navigate command history
+              <span className="text-tui-accent-dim">· </span>
+              <span className="text-terminal-bright-green font-mono">↑↓</span> to navigate command history
             </div>
             <div>
-              <span className="text-white">• </span>Use{' '}
-              <span className="text-terminal-bright-green font-semibold">Ctrl+C</span> to
-              interrupt current operation
+              <span className="text-tui-accent-dim">· </span>
+              <span className="text-terminal-bright-green font-mono">ctrl+c</span> to clear input
             </div>
             <div>
-              <span className="text-white">• </span>Use{' '}
-              <span className="text-terminal-bright-green font-semibold">Ctrl+L</span> to clear
-              screen quickly
+              <span className="text-tui-accent-dim">· </span>
+              <span className="text-terminal-bright-green font-mono">ctrl+l</span> to clear screen
             </div>
             <div>
-              <span className="text-white">• </span>Click anywhere on the terminal to focus input
+              <span className="text-tui-accent-dim">· </span>
+              click anywhere to focus input
             </div>
           </div>
         </div>
-        <div className="text-terminal-white text-center pt-2 border-t border-terminal-green/30">
-          Start with <CmdLink cmd="about" className="hover:text-terminal-yellow">about</CmdLink> to
-          learn more about me, or try{' '}
-          <CmdLink cmd="neofetch" className="hover:text-terminal-yellow">neofetch</CmdLink> for a
-          quick overview.
+        <div className="text-white/70 pt-2 border-t border-tui-accent-dim/30 text-xs">
+          start with <CmdLink cmd="about">about</CmdLink>{' '}
+          — or try <CmdLink cmd="neofetch">neofetch</CmdLink> for a quick overview.
         </div>
       </SectionBox>,
       'w-full',
@@ -639,20 +626,20 @@ export function useTerminal({ portfolioData, onSwitchToGUI }: UseTerminalProps) 
         bodyClassName="p-3 space-y-3 text-xs sm:text-sm"
       >
         <div>
-          <div className="text-terminal-bright-green font-bold mb-2">👋 INTRODUCTION</div>
-          <div className="space-y-2 ml-2">
+          <div className="text-tui-accent-dim text-xs mb-2">// intro</div>
+          <div className="space-y-2 ml-1">
             {(cv.sections?.intro ?? []).map((paragraph, i) => (
               <div
                 key={i}
-                className="text-white leading-relaxed bg-terminal-green/5 p-2 rounded"
+                className="text-white leading-relaxed border-l-2 border-tui-accent-dim/40 pl-3"
                 dangerouslySetInnerHTML={{ __html: inlineMd(paragraph) }}
               />
             ))}
           </div>
         </div>
         <div>
-          <div className="text-terminal-bright-green font-bold mb-2">🔗 QUICK LINKS</div>
-          <div className="space-y-1 ml-2">
+          <div className="text-tui-accent-dim text-xs mb-2">// links</div>
+          <div className="space-y-1 ml-1">
             {cv.website ? (
               <LabeledRow label="Portfolio">
                 <a href={cv.website} className="hover:text-terminal-bright-green">
@@ -1357,27 +1344,27 @@ export function useTerminal({ portfolioData, onSwitchToGUI }: UseTerminalProps) 
     const searchTerm = args.join(' ').toLowerCase();
     if (!searchTerm) {
       addNode(
-        <SectionBox title="SEARCH USAGE" centerTitle>
+        <Block title="// search">
           <div>
-            <div className="text-terminal-yellow font-bold mb-2">📋 USAGE</div>
-            <div className="ml-2 space-y-1">
-              <div className="text-white bg-terminal-green/5 p-2 rounded">
-                <span className="text-terminal-bright-green font-semibold">search</span>{' '}
-                <span className="text-terminal-yellow">[term]</span>
+            <div className="text-tui-accent-dim text-xs mb-2">// usage</div>
+            <div className="ml-1">
+              <div className="text-white border-l-2 border-tui-accent-dim/40 pl-3 py-1">
+                <span className="text-terminal-bright-green">search</span>{' '}
+                <span className="text-tui-accent-dim">[term]</span>
               </div>
             </div>
           </div>
           <div>
-            <div className="text-terminal-yellow font-bold mb-2">💡 EXAMPLES</div>
-            <div className="ml-2 space-y-1">
+            <div className="text-tui-accent-dim text-xs mb-2">// examples</div>
+            <div className="ml-1 space-y-0.5">
               {['python', 'react', 'machine learning'].map((ex) => (
-                <div key={ex} className="text-white bg-terminal-green/5 p-2 rounded">
+                <div key={ex} className="text-white/80 border-l-2 border-tui-accent-dim/40 pl-3 py-0.5 text-xs">
                   <span className="text-terminal-bright-green">search</span> {ex}
                 </div>
               ))}
             </div>
           </div>
-        </SectionBox>,
+        </Block>,
         'w-full',
       );
       return;
@@ -1611,8 +1598,8 @@ export function useTerminal({ portfolioData, onSwitchToGUI }: UseTerminalProps) 
         bodyClassName="p-3 space-y-3 text-xs sm:text-sm"
       >
         <div>
-          <div className="text-terminal-bright-green font-bold mb-2">📞 PERSONAL DETAILS</div>
-          <div className="space-y-1 ml-2">
+          <div className="text-tui-accent-dim text-xs mb-2">// personal</div>
+          <div className="space-y-1 ml-1">
             <Row label="Name" value={cv.name} />
             <Row label="Location" value={cv.location} />
             <Row label="Email" value={cv.email} />
@@ -1634,8 +1621,8 @@ export function useTerminal({ portfolioData, onSwitchToGUI }: UseTerminalProps) 
           </div>
         </div>
         <div>
-          <div className="text-terminal-bright-green font-bold mb-2">🌐 SOCIAL NETWORKS</div>
-          <div className="space-y-1 ml-2">
+          <div className="text-tui-accent-dim text-xs mb-2">// social</div>
+          <div className="space-y-1 ml-1">
             {cv.social_networks?.map((social) => (
               <Row
                 key={social.network}
@@ -1668,15 +1655,30 @@ export function useTerminal({ portfolioData, onSwitchToGUI }: UseTerminalProps) 
       return;
     }
     const role = portfolioData.cv.sections?.experience?.[0]?.position || uiText.labels.professional;
+    const firstCompany = portfolioData.cv.sections?.experience?.[0]?.company;
     const Row = ({ label, value }: { label: string; value: string | undefined }) => (
-      <CompactRow label={label} value={value ?? '—'} labelWidth="w-20" />
+      <CompactRow label={label} value={value ?? '—'} labelWidth="w-24" />
     );
+    // Rough uptime: time since the page loaded (session duration).
+    const uptimeSec = Math.floor(performance.now() / 1000);
+    const uptimeStr =
+      uptimeSec < 60
+        ? `${uptimeSec}s`
+        : uptimeSec < 3600
+          ? `${Math.floor(uptimeSec / 60)}m ${uptimeSec % 60}s`
+          : `${Math.floor(uptimeSec / 3600)}h ${Math.floor((uptimeSec % 3600) / 60)}m`;
     addNode(
-      <SectionBox title="WHOAMI" bodyClassName="p-3 space-y-1 text-xs sm:text-sm">
-        <Row label="User" value={portfolioData.cv.name} />
-        <Row label="Location" value={portfolioData.cv.location} />
-        <Row label="Role" value={role} />
-      </SectionBox>,
+      <Block title="// whoami">
+        <div className="space-y-1 font-mono">
+          <Row label="user" value={portfolioData.cv.name?.toLowerCase().replace(/\s+/g, '')} />
+          <Row label="display" value={portfolioData.cv.name} />
+          <Row label="role" value={role} />
+          {firstCompany && <Row label="company" value={firstCompany} />}
+          <Row label="location" value={portfolioData.cv.location} />
+          <Row label="shell" value="nagoya · portfolio tui v2.0" />
+          <Row label="uptime" value={uptimeStr} />
+        </div>
+      </Block>,
       'w-full',
     );
   }, [addLine, addNode, portfolioData]);
@@ -1685,10 +1687,16 @@ export function useTerminal({ portfolioData, onSwitchToGUI }: UseTerminalProps) 
     const filename = args[0];
     if (!filename) {
       addNode(
-        <SectionBox title="CAT COMMAND" centerTitle bodyClassName="p-3 space-y-2 text-xs sm:text-sm">
-          <div className="text-terminal-yellow font-semibold">Usage: cat [filename]</div>
-          <div className="text-white">Available files: resume.txt</div>
-        </SectionBox>,
+        <Block title="// cat">
+          <div className="text-tui-accent-dim text-xs mb-1">// usage</div>
+          <div className="text-white text-xs border-l-2 border-tui-accent-dim/40 pl-3 mb-2">
+            cat <span className="text-tui-accent-dim">[filename]</span>
+          </div>
+          <div className="text-tui-accent-dim text-xs mb-1">// available</div>
+          <div className="text-white text-xs border-l-2 border-tui-accent-dim/40 pl-3">
+            resume.txt
+          </div>
+        </Block>,
         'w-full',
       );
       return;
@@ -1697,7 +1705,7 @@ export function useTerminal({ portfolioData, onSwitchToGUI }: UseTerminalProps) 
     if (filename !== 'resume.txt') {
       // Unix-literal — no bespoke red box. Matches the terse tone of
       // every other shell error ("bash: foo: command not found").
-      addLine(`cat: ${filename}: No such file or directory`, 'text-tui-error');
+      addLine(`cat: ${filename}: no such file or directory`, 'text-tui-error');
       return;
     }
 
@@ -1710,8 +1718,8 @@ export function useTerminal({ portfolioData, onSwitchToGUI }: UseTerminalProps) 
 
     const Bullet = ({ html }: { html: string }) => (
       <div
-        className="text-white text-xs leading-relaxed bg-terminal-green/10 p-2 rounded"
-        dangerouslySetInnerHTML={{ __html: `• ${html}` }}
+        className="text-white text-xs leading-relaxed border-l-2 border-tui-accent-dim/40 pl-3"
+        dangerouslySetInnerHTML={{ __html: `· ${html}` }}
       />
     );
 
@@ -1996,7 +2004,7 @@ export function useTerminal({ portfolioData, onSwitchToGUI }: UseTerminalProps) 
         <div>└{border}┘</div>
         <div>{'\u00A0'}</div>
         <div className="text-tui-muted">
-          💡 Tip: Create a custom banner by adding client/public/data/neofetch.txt
+          tip: create a custom banner by adding client/public/data/neofetch.txt
         </div>
         <div>{'\u00A0'}</div>
       </div>,
@@ -2208,7 +2216,7 @@ export function useTerminal({ portfolioData, onSwitchToGUI }: UseTerminalProps) 
         break;
       case 'gui':
         if (onSwitchToGUI) {
-          addLine('Switching to GUI view...', 'text-terminal-yellow');
+          addLine('switching to gui…', 'text-tui-accent-dim');
           // One paint to flush the banner, then hand off — no arbitrary delay.
           requestAnimationFrame(() => onSwitchToGUI());
         } else {

--- a/client/src/index.css
+++ b/client/src/index.css
@@ -32,7 +32,7 @@
 
   /* TUI semantic tokens — theme-following. See applyColorTheme(). */
   --tui-accent-dim: hsl(120, 70%, 35%);   /* darker-hue label color; follows theme */
-  --tui-muted: hsl(120, 15%, 60%);        /* secondary/chrome text; follows theme hue */
+  --tui-muted: hsl(120, 12%, 60%);        /* very low-sat gray + whisper of hue */
   --tui-error: hsl(0, 100%, 60%);         /* errors are universal red, never themed */
   --tui-warn: hsl(45, 100%, 55%);         /* warnings are universal amber */
 

--- a/client/src/index.css
+++ b/client/src/index.css
@@ -31,7 +31,7 @@
   --glow-color-rgb: 0, 255, 0;
 
   /* TUI semantic tokens — theme-following. See applyColorTheme(). */
-  --tui-accent-dim: hsl(120, 70%, 35%);   /* darker-hue label color; follows theme */
+  --tui-accent-dim: hsl(120, 80%, 42%);   /* darker-hue label color; follows theme */
   --tui-muted: hsl(120, 12%, 60%);        /* very low-sat gray + whisper of hue */
   --tui-error: hsl(0, 100%, 60%);         /* errors are universal red, never themed */
   --tui-warn: hsl(45, 100%, 55%);         /* warnings are universal amber */

--- a/client/src/index.css
+++ b/client/src/index.css
@@ -28,9 +28,18 @@
   --terminal-bright-green: hsl(120, 100%, 60%);
   --terminal-black: hsl(0, 0%, 0%);
   --terminal-white: hsl(0, 0%, 100%);
-  --terminal-red: hsl(0, 100%, 50%);
-  --terminal-yellow: hsl(60, 100%, 50%);
   --glow-color-rgb: 0, 255, 0;
+
+  /* TUI semantic tokens — theme-following. See applyColorTheme(). */
+  --tui-accent-dim: hsl(120, 70%, 35%);   /* darker-hue label color; follows theme */
+  --tui-muted: hsl(120, 15%, 60%);        /* secondary/chrome text; follows theme hue */
+  --tui-error: hsl(0, 100%, 60%);         /* errors are universal red, never themed */
+  --tui-warn: hsl(45, 100%, 55%);         /* warnings are universal amber */
+
+  /* Backwards-compat aliases — old `text-terminal-yellow`/`text-terminal-red`
+     classes still work, and now pick up the theme-following semantics above. */
+  --terminal-yellow: var(--tui-accent-dim);
+  --terminal-red: var(--tui-error);
 
   /* GUI Portfolio variables — update gui-theme.config.ts to change theme */
   --gui-bg: #000000;
@@ -119,7 +128,9 @@ html {
     right: 0;
     bottom: 0;
     pointer-events: none;
-    background: linear-gradient(transparent 50%, rgba(0, 255, 0, 0.03) 50%);
+    /* Scanline tint follows the active theme hue instead of being baked
+       matrix-green — a Glacier theme now has glacier-tinted scanlines. */
+    background: linear-gradient(transparent 50%, rgba(var(--glow-color-rgb), 0.03) 50%);
     background-size: 100% 4px;
     opacity: 0.1;
   }
@@ -132,12 +143,14 @@ html {
   }
   
   .terminal-glow {
-    box-shadow: 0 0 20px rgba(var(--glow-color-rgb), 0.2), inset 0 0 20px rgba(var(--glow-color-rgb), 0.1);
+    /* Outer glow only — the previous `inset` + outer combo caused
+       `Block`-in-frame nested glows that muddied on saturated themes. */
+    box-shadow: 0 0 20px rgba(var(--glow-color-rgb), 0.2);
   }
 
   @media (max-width: 768px) {
     .terminal-glow {
-      box-shadow: 0 0 10px rgba(var(--glow-color-rgb), 0.15), inset 0 0 10px rgba(var(--glow-color-rgb), 0.05);
+      box-shadow: 0 0 10px rgba(var(--glow-color-rgb), 0.15);
     }
   }
 

--- a/client/src/index.css
+++ b/client/src/index.css
@@ -227,7 +227,9 @@ html {
     background: rgba(0, 255, 0, 0.15);
   }
 
-  /* Film grain overlay */
+  /* Film grain overlay — applied site-wide on both TUI and GUI so
+     the two views share one atmospheric noise floor. Paused when
+     prefers-reduced-motion is set. */
   .film-grain {
     position: fixed;
     inset: 0;
@@ -235,6 +237,11 @@ html {
     pointer-events: none;
     opacity: 0.035;
     animation: grain 0.5s steps(6) infinite;
+  }
+  @media (prefers-reduced-motion: reduce) {
+    .film-grain {
+      animation: none;
+    }
   }
   @keyframes grain {
     0%, 100% { transform: translate(0, 0); }

--- a/client/src/lib/fieldRenderer.ts
+++ b/client/src/lib/fieldRenderer.ts
@@ -172,9 +172,9 @@ export function renderCustomFields(
   }
 
   return `
-    <div class="mt-2 pt-2 border-t border-terminal-green/20">
-      <div class="text-terminal-bright-green font-semibold text-xs mb-2">📋 Additional Info:</div>
-      <div class="ml-2 space-y-1">
+    <div class="mt-2 pt-2 border-t border-tui-accent-dim/30">
+      <div class="text-tui-accent-dim text-xs mb-2">// additional</div>
+      <div class="ml-1 space-y-1">
         ${fieldsHtml}
       </div>
     </div>

--- a/client/src/lib/platform.ts
+++ b/client/src/lib/platform.ts
@@ -1,0 +1,33 @@
+/**
+ * Platform detection — used by the TUI to swap keyboard chip labels
+ * (⌃ / ⌥ on Mac vs Ctrl / Alt elsewhere) and to gate behaviors that
+ * don't make sense on touch devices (modifier-key shortcuts).
+ *
+ * Computed once at module load. Pure read-only constants.
+ */
+
+function detectMac(): boolean {
+  if (typeof navigator === 'undefined') return false;
+  // Modern API (Chromium-based); fall back to legacy navigator.platform
+  // which is still the most reliable cross-browser signal as of writing.
+  // navigator.userAgentData is not yet in lib.dom.d.ts in our version.
+  const uad = (navigator as unknown as { userAgentData?: { platform?: string } })
+    .userAgentData;
+  if (uad?.platform) return /mac/i.test(uad.platform);
+  return /Mac|iPhone|iPad|iPod/.test(navigator.platform || '');
+}
+
+function detectTouch(): boolean {
+  if (typeof window === 'undefined') return false;
+  if (window.matchMedia('(pointer: coarse)').matches) return true;
+  return 'ontouchstart' in window;
+}
+
+export const isMacPlatform = detectMac();
+export const isTouchDevice = detectTouch();
+/** Mac with a real keyboard — show the ⌃/⌥ symbols. */
+export const isMacDesktop = isMacPlatform && !isTouchDevice;
+
+/** Render-ready labels for modifier keys, swapping per platform. */
+export const ctrlKey = isMacDesktop ? '⌃' : 'Ctrl ';
+export const altKey = isMacDesktop ? '⌥' : 'Alt ';

--- a/package.json
+++ b/package.json
@@ -30,6 +30,7 @@
     "npm": ">=9.0.0"
   },
   "scripts": {
+    "predev": "node scripts/generate-ai-prompt.js",
     "dev": "vite",
     "build": "node scripts/build.js",
     "preview": "vite preview",
@@ -38,8 +39,9 @@
     "generate-resume:dev": "NODE_ENV=development node scripts/generate-resume.js",
     "generate-resume:prod": "NODE_ENV=production node scripts/generate-resume.js",
     "generate-resume:ci": "NODE_ENV=ci node scripts/generate-resume.js",
+    "generate-ai-prompt": "node scripts/generate-ai-prompt.js",
     "type-check": "tsc --noEmit",
-    "setup": "npm install && npm run generate-resume",
+    "setup": "npm install && npm run generate-resume && npm run generate-ai-prompt",
     "clean": "rm -rf dist node_modules client/public/data/*.json client/public/resume.* rendercv_output"
   },
   "dependencies": {

--- a/scripts/generate-ai-prompt.js
+++ b/scripts/generate-ai-prompt.js
@@ -45,8 +45,13 @@ const exampleYaml = readFileSync(examplePath, 'utf-8');
 function parseSchema(schemaContent) {
   const schemas = {};
 
-  // Extract each schema definition
-  const schemaRegex = /export const (\w+)Schema = z\.object\(\{([^}]+)\}\);/gs;
+  // Extract each schema definition. The trailing `[^;]*` allows for
+  // chained method calls — every schema in shared/schema.ts ends with
+  // `.passthrough()` (or potentially `.refine()`, etc.), and without
+  // this the regex matched zero schemas, leaving every section in the
+  // generated prompt as a bare header (`education:`) with no field
+  // list — so the AI couldn't see which fields were REQUIRED.
+  const schemaRegex = /export const (\w+)Schema = z\.object\(\{([^}]+)\}\)[^;]*;/gs;
   let match;
 
   while ((match = schemaRegex.exec(schemaContent)) !== null) {
@@ -322,87 +327,228 @@ function generateSchemaDoc(schemas) {
 const schemaDoc = generateSchemaDoc(schemas);
 
 // Generate the comprehensive prompt
-const prompt = `# Resume to YAML Converter - AI Assistant Prompt
+const prompt = `# Resume → resume.yaml — AI Converter
 
-You are a professional resume conversion specialist. Your task is to convert a user's resume into a specific YAML format used for terminal-style portfolio websites.
+You convert resumes into a valid \`resume.yaml\` for a terminal-themed
+portfolio site (https://github.com/subhayu99/subhayu99.github.io).
+The user will paste your YAML output into their fork and deploy.
 
-## YAML Schema Specification
+**Be terse. Make decisions. Minimize turns.** Aim for **2 turns** end-
+to-end whenever possible: one clarification message, then YAML.
 
-The resume follows this exact structure. All fields marked as "Optional" can be omitted if not applicable.
+---
+
+## Required vs optional — read this before anything else
+
+Two classes of fields. They are **NOT** treated the same.
+
+**REQUIRED fields** (zod schema enforces — output WILL be rejected if
+missing):
+
+- \`cv.name\`
+- \`social_networks[]\`: \`network\`, \`username\`
+- \`technologies[]\`: \`label\`, \`details\`
+- \`experience[]\`: \`company\`, \`position\`, **\`start_date\`**
+- \`education[]\`: \`institution\`, \`area\`, \`degree\`, **\`start_date\`**
+- \`professional_projects[]\` / \`personal_projects[]\`: \`name\`, \`date\`
+- \`publication[]\`: \`title\`, \`authors\`, \`date\`, \`journal\`
+
+**OPTIONAL fields** — anything else (location, end_date, highlights,
+tagline, website, phone, email, resume_url, etc.). The schema doc
+below marks every field with REQUIRED or Optional — re-check it.
+
+The split rule that governs everything below:
+
+| field type | if missing from input | what you do                                         |
+|------------|-----------------------|-----------------------------------------------------|
+| REQUIRED   | ask in turn 1         | **NEVER guess. NEVER hallucinate. NEVER omit.**     |
+| OPTIONAL   | use your best guess   | flag with \`[g]\` in the post-yaml summary           |
+
+A REQUIRED-field guess is **not allowed**. If a required field has no
+trustworthy source (resume + user reply), you **MUST NOT** generate
+YAML — instead, send a short follow-up asking for ONLY the missing
+required fields.
+
+---
+
+## How to work
+
+**Turn 1 — read what you got, then send ONE message that does all of:**
+
+1. **Acknowledge** in 1-2 lines what you found (e.g.,
+   \`found: 5 roles · 1 degree · 9 skill groups · 0 publications\`).
+   No "do you want to proceed?" gate.
+
+2. **Audit required fields.** Mentally walk every entry against the
+   REQUIRED list above. If the resume is missing a required field for
+   any entry, that question goes at the **TOP** of your numbered list,
+   tagged \`[required]\`. Example:
+
+   > 1. **[required]** education — DTU entry has no \`start_date\`.
+   >    when did your B.Tech start? (YYYY-MM)
+   > 2. **[required]** experience — Zeta role has no \`start_date\`.
+   >    YYYY-MM?
+
+   Required-field questions are **not** opt-in. Make this clear:
+   > [required] questions can't be skipped — i need a value for the
+   > yaml to validate.
+
+3. **Then ask the optional clarifications** below the required ones.
+   Bundle them into the same numbered list. For optionals, default
+   guesses inline:
+
+   > 3. tagline (optional) — none on resume. i'll use \`founding
+   >    engineer building genai products at scale\` unless you give a
+   >    better one.
+   > 4. skill grouping (optional) — i'll group by domain unless you
+   >    want by-proficiency or flat.
+   > 5. social handles (optional, usernames only): github? linkedin?
+   > 6. ...
+
+4. **State the skip rule clearly:**
+   > skip optional items → i'll guess and flag with [g].
+   > [required] items → please answer; i can't generate without them.
+
+**Turn 2 — generate (or ask again).**
+
+Before generating, re-check: are all REQUIRED fields now satisfied
+from (resume ∪ user reply)? If yes → output YAML. If any required
+field still missing → send a short message listing only those
+unanswered required questions. **Do not output partial / placeholder
+YAML.** Loop until required fields are complete.
+
+When you do generate, output the YAML in one code block. Then in 3-5
+short lines below it, list the guesses you made for OPTIONAL fields:
+
+> [g] tagline — used "founding engineer ..."; change with: "tagline: ..."
+> [g] split — colbin as personal_projects only
+> [g] phone — formatted as tel:+91-8800832389
+
+Required fields never appear in the \`[g]\` list — they came from the
+user, not a guess.
+
+**Turn 3+ — iterate (only if they ask).** They'll say what to change in
+plain English. Apply it. Show the changed snippet (or full file if
+structure changed). No numbered tweak menu — just do it.
+
+---
+
+## What to never do
+
+- **Don't gate (between turns).** No "ok?" / "ready?" / "shall i
+  proceed?" Procedural prompts kill flow.
+- **Don't batch.** All clarifying questions go in one message.
+- **Don't ask what you can guess** (for OPTIONAL fields only). Skill
+  grouping, project split, bolding policy — pick a default, name it,
+  let the user override.
+- **Don't ever guess REQUIRED fields.** No assumed start_date "looks
+  like 2014 based on graduation year". Ask. If unanswered → ask
+  again. Don't generate.
+- **Don't generate YAML when any REQUIRED field is unsatisfied** —
+  even if the user says "go" or "looks good". A missing required field
+  means the YAML will fail schema validation downstream. Re-ask
+  instead.
+- **Don't omit required fields silently** by leaving them out of the
+  YAML hoping zod will accept it — zod won't.
+- **Don't lecture** unless asked. If the user gives a weak tagline,
+  use it. If they want feedback, they'll ask.
+- **Don't re-ask** in turn 2 what you already asked in turn 1. If they
+  skipped an OPTIONAL item, use your guess. If they skipped a REQUIRED
+  item, the only thing you re-ask is THAT specific required item.
+- **Don't generate placeholder YAML** in turn 1.
+
+---
+
+## When to push back (briefly)
+
+- **Vague highlights with no metric:** ask for one in turn 1's
+  question list. If the user skips → keep the highlight vague, don't
+  invent numbers, flag with \`[g]\`.
+- **HR-speak in their resume:** rewrite silently. Don't ask.
+  - "Synergized cross-functional teams" → "Shipped onboarding flow
+    across 4 designers + 2 PMs."
+  - "Spearheaded initiative" → "Led [thing], ship date [X]."
+  - "Leveraged technologies" → "Used [stack]."
+- **Conflicting facts** (same role twice, dates that don't add up):
+  ask once in turn 1. Pick the more specific version if user skips.
+
+---
+
+## Highlight rewrite patterns (apply silently in turn 2)
+
+| vague                                | rewrite (when metric available)                                                              |
+|--------------------------------------|----------------------------------------------------------------------------------------------|
+| "Improved API performance."          | "**Cut p99 latency 1.2s → 280ms** with async handlers + Redis cache."                        |
+| "Managed engineering team."          | "Led **5 engineers** for **3 quarters**; shipped auth migration with **0 prod incidents**." |
+| "Worked on data pipelines."          | "Built ingestion pipeline at **2.3B events/day**; cut lag from **6h → 12m**."               |
+| "Reduced cloud costs."               | "Cut AWS spend by **$47k/yr** (-32%) via spot autoscaling + S3 lifecycle policies."         |
+| "Worked closely with stakeholders."  | (drop unless metric available — too vague to rescue)                                        |
+
+---
+
+## Hard rules (apply on every YAML output)
+
+0. **Required-field gate (highest priority).** Before outputting,
+   verify every entry has all its REQUIRED fields (see the table
+   above). Even one missing required field → DO NOT generate. Ask
+   for the missing values and try again next turn.
+1. Root key is \`cv:\`. Nothing else at top level.
+2. Schema field names match exactly. **Never invent fields.**
+3. Dates: \`"YYYY-MM"\` (or \`"YYYY-MM – YYYY-MM"\` ranges, em-dash).
+4. Currently-employed roles: **omit** \`end_date\` (it's optional).
+5. Social handles: **usernames only** (\`subhayu99\`), never URLs.
+6. Phone: \`tel:+...\` prefix.
+7. **Bold every metric** (numbers, %, scale, latency, $) with \`**...**\`.
+8. **Action verb** at the start of every highlight (Built, Led, Cut,
+   Shipped, Migrated, Architected, ...). No "Responsible for..." /
+   "Worked on...".
+9. Drop empty OPTIONAL sections entirely. No \`section: []\` / \`{}\`.
+10. **2-space indent**, no tabs.
+11. Quote any string containing \`: { } [ ] # > | & * ! % @\` or starting
+    with a digit.
+12. **Never hallucinate** REQUIRED fields (dates, names, etc.). For
+    OPTIONAL fields, guess + flag with \`[g]\` is fine. For REQUIRED
+    fields, asking is the only option.
+
+---
+
+## YAML schema (the exact structure your output must follow)
 
 \`\`\`yaml
 ${schemaDoc}
 \`\`\`
 
-## Formatting Guidelines
+---
 
-Follow these rules strictly to ensure proper YAML syntax and consistent formatting:
+## Reference example (a complete, valid \`resume.yaml\`)
 
-### 1. Date Formats
-- Use **"YYYY-MM"** format for all dates (e.g., "2024-01", "2021-06")
-- For date ranges, use: "YYYY-MM – YYYY-MM" (em dash: –)
-- For publications, use: "YYYY-MM-DD" format
-- **Omit end_date** for current positions/roles
-
-### 2. Text Formatting
-- **Bold important metrics**: Use \`**text**\` for numbers, percentages, achievements
-  - Example: "Increased revenue by **40%**", "Led team of **5 engineers**"
-- **Markdown links**: Use \`[link text](url)\` format
-  - Example: "[GitHub](https://github.com/username)"
-- **Action verbs**: Start each highlight with strong action verbs
-  - Examples: Built, Developed, Architected, Led, Implemented, Optimized, Designed
-
-### 3. YAML Syntax
-- **Indentation**: Use exactly 2 spaces per level (no tabs)
-- **Strings**: Use quotes for strings containing special characters (: - [ ] { } # | > etc.)
-- **Arrays**: Use \`-\` for array items, indented consistently
-- **Comments**: Lines starting with \`#\` are comments (optional, for clarity)
-
-### 4. Content Guidelines
-- **Be specific**: Include concrete metrics, numbers, and outcomes
-- **Quantify impact**: Always include percentages, numbers, scale where possible
-- **Highlight achievements**: Focus on results and impact, not just responsibilities
-- **Use industry terms**: Include relevant technical keywords and technologies
-- **Keep it concise**: Each highlight should be 1-2 lines, clear and impactful
-
-### 5. Optional Sections
-- **Omit empty sections**: If a section doesn't apply, remove it entirely
-- **Don't leave empty arrays**: Remove the section rather than leaving \`section: []\`
-
-## Complete Example
-
-Here's a full example resume in the correct format. Use this as your reference:
+Match the indentation, comment style, and overall shape — but
+**don't copy the content**.
 
 \`\`\`yaml
 ${exampleYaml}
 \`\`\`
 
-## Your Conversion Task
+---
 
-Now, convert the user's resume (provided below) into the exact YAML format specified above.
+## Begin
 
-**Instructions:**
-1. **Preserve all information** from the original resume
-2. **Format dates** consistently as "YYYY-MM"
-3. **Add bold formatting** (\`**text**\`) to all metrics, numbers, and key achievements
-4. **Use action verbs** to start each highlight
-5. **Ensure proper YAML indentation** (2 spaces per level)
-6. **Omit empty sections** that don't apply
-7. **Validate output** to ensure it's valid YAML syntax
-8. **Add section comments** (#) for clarity if helpful
+The user's input is below. It may be a full resume (pdf / text /
+linkedin export), a partial one, or nothing (interview from scratch).
 
-**Output Requirements:**
-- Start with \`cv:\` at the root level
-- Follow the exact structure shown in the schema
-- Include ALL applicable sections from the original resume
-- Format everything exactly as shown in the example
-- Make highlights impactful and results-oriented
+- If it's a resume: extract aggressively, then send your turn-1
+  message (acknowledge + bundled questions).
+- If it's nothing or just a hi: send turn-1 as the irreducible
+  ~12-question intake (name, location, email, phone, current role +
+  company, last 2-3 roles with company + dates + 2-3 highlights each,
+  education, top skills, github/linkedin handles, tagline). Same
+  shape — one numbered list, skip = guess.
+
+No handshake. No "which mode?". Just read and respond.
 
 ---
 
-## User's Resume (to be converted):
-
-[PASTE OR ATTACH YOUR RESUME BELOW THIS LINE]
+[PASTE / ATTACH YOUR RESUME HERE — OR JUST SAY HI]
 
 `;
 

--- a/tailwind.config.ts
+++ b/tailwind.config.ts
@@ -67,6 +67,13 @@ export default {
         "terminal-white": "var(--terminal-white)",
         "terminal-red": "var(--terminal-red)",
         "terminal-yellow": "var(--terminal-yellow)",
+        // TUI semantic tokens — new code uses these. `terminal-yellow` and
+        // `terminal-red` above are backwards-compat aliases pointing at the
+        // same CSS vars.
+        "tui-accent-dim": "var(--tui-accent-dim)",
+        "tui-muted": "var(--tui-muted)",
+        "tui-error": "var(--tui-error)",
+        "tui-warn": "var(--tui-warn)",
         gui: {
           bg: "var(--gui-bg)",
           surface: "var(--gui-surface)",


### PR DESCRIPTION
## Summary

Syncs the 23 commits from PR #10 (`personal` branch) into `main`. None of the commits touch personal-only files (resume.yaml, generated assets in `client/public/data/`, icons, etc.) so all are safe to land on the template branch.

This brings to `main`:

- **TUI revamp (phases 0-13)** — Block primitive, Starship-style prompt, command palette (Ctrl+K), reverse-search (Ctrl+R), vim `:` colon mode, numbered-link `o N` addressing, Charm-Glow markdown rendering, Braille sparklines + `stats` command, CRT boot sequence, idle matrix-rain screensaver, theme-following tokens, hidden easter-egg commands, `rm -rf /` deletion theater, accessibility/atmosphere polish.
- **Several audit passes** — playwright-driven bug sweep, second-pass consistency sweep, prompt + status bar width capping, theme-chrome cleanup (right/bottom borders, amber olive cast), theme persistence on every mount.
- **Final audit pass (this session's 3 commits)** —
  - autocomplete suppresses subcommands until base + space, no more 1-row redundant dropdown, `useMemo` prevents arrow-key reset
  - `rm` parses flags vs operands properly (`cannot remove 'd'` not `'-rf d'`); detects `-rf /` regardless of order
  - bare-key shortcuts (`?`, `/`, `:`) only fire on empty input — typing `/` mid-command no longer hijacks to search
  - reverse-search hints moved into StatusBar (no extra row above it)
  - removed misleading `o N` chip and `[N]` link suffixes
  - Alt+M / matrix chip is now a true silent persistent toggle (no scrollback echo)
  - matrix rain head color uniform with trail (no white tip)
  - `whoami` / `neofetch` / `stats` no longer pin prompt to `~/whoami`
  - section commands short-circuit re-runs while already in section
  - welcome banner left rail removed; "talks back" greeting removed
  - text sizing unified across prompt, input, ghost, lines, dropdown
- **Replicate page restructure** — linear `step 1 → step 2 → what you get` flow, prominent `[ get ai prompt ]` CTA explaining it gives a prompt for ChatGPT/Claude/Gemini, boxed `⚠` warning for the actions+pages gotcha, collapsible advanced mode, `<your-username>` placeholder convention.
- **AI resume-conversion prompt rewrite + schema regex bug fix** — schema doc was rendering empty section bodies because the regex didn't account for `.passthrough()` chains; fixed. Prompt redesigned around 2-turn conversational flow with hard required-field gating that blocks YAML output until every required field is satisfied. Added `predev` npm script so the prompt is always fresh.

## Test plan

- [x] All 23 commits cherry-picked clean off `origin/main` — no conflicts
- [x] Type-check passes (only pre-existing SectionWrapper errors remain, unrelated)
- [x] No personal-file touches in any commit (verified with sync-branches.sh's pattern list inline)
- [ ] Reviewer: `npm install && npm run dev` — verify TUI loads, all commands work, no console errors
- [ ] Reviewer: open `replicate` command, click `[ get ai prompt ]`, verify modal opens with regenerated prompt

🤖 Generated with [Claude Code](https://claude.com/claude-code)