### PR TITLE
fix(tui): mobile keyboard reflow + reachable chips on touch

### DIFF
--- a/client/src/components/Terminal.tsx
+++ b/client/src/components/Terminal.tsx
@@ -615,7 +615,7 @@ function Terminal({ onSwitchToGUI }: TerminalProps) {
   // Render loading or error states
   if (isLoading) {
     return (
-      <div className="terminal-glow terminal-scanlines relative w-full h-screen bg-terminal-black">
+      <div className="terminal-glow terminal-scanlines relative w-full h-dvh bg-terminal-black">
         <div className="flex items-center justify-center h-full">
           <div className="text-terminal-green">
             <div className="mb-4">{uiText.loading.text}</div>
@@ -628,7 +628,7 @@ function Terminal({ onSwitchToGUI }: TerminalProps) {
 
   if (error) {
     return (
-      <div className="terminal-glow terminal-scanlines relative w-full h-screen bg-terminal-black">
+      <div className="terminal-glow terminal-scanlines relative w-full h-dvh bg-terminal-black">
         <div className="flex items-center justify-center h-full">
           <div className="text-terminal-red">
             <div className="mb-4">{uiText.loading.error}:</div>
@@ -641,7 +641,10 @@ function Terminal({ onSwitchToGUI }: TerminalProps) {
   }
 
   return (
-    <div className="terminal-glow terminal-scanlines relative w-full h-screen bg-terminal-black">
+    // h-dvh so the layout shrinks with the visual viewport when the
+    // mobile soft keyboard opens — h-screen (100vh) is fixed to the
+    // page height and lets the keyboard cover the input + status bar.
+    <div className="terminal-glow terminal-scanlines relative w-full h-dvh bg-terminal-black">
       {/* Shared film-grain atmosphere — also used by the GUI so both
            views share one noise floor. Paused on reduced-motion. */}
       <div className="film-grain" aria-hidden="true" />

--- a/client/src/components/TerminalView.tsx
+++ b/client/src/components/TerminalView.tsx
@@ -12,7 +12,7 @@ function TerminalView() {
       animate={{ opacity: 1 }}
       exit={{ opacity: 0 }}
       transition={{ duration: 0.4 }}
-      className="w-full h-screen overflow-hidden relative"
+      className="w-full h-dvh overflow-hidden relative"
     >
       <Terminal onSwitchToGUI={() => switchTo('gui')} />
 

--- a/client/src/components/tui/StatusBar.tsx
+++ b/client/src/components/tui/StatusBar.tsx
@@ -56,7 +56,10 @@ export function StatusBar({
     <footer
       role="toolbar"
       aria-label="terminal hints"
-      className="flex-shrink-0 border-t border-tui-accent-dim/30 bg-terminal-black px-2 sm:px-3 py-1 font-mono text-[10px] sm:text-[11px] leading-tight"
+      // pb adds safe-area for iPhones with a home bar so chips don't
+      // sit under the indicator. With h-dvh on the outer shell, the
+      // strip lifts above the soft keyboard automatically when it opens.
+      className="flex-shrink-0 border-t border-tui-accent-dim/30 bg-terminal-black px-2 sm:px-3 py-1 pb-[max(0.25rem,env(safe-area-inset-bottom))] font-mono text-[10px] sm:text-[11px] leading-tight"
     >
       <div className="max-w-4xl flex items-center gap-x-3">
         {mode === 'search' ? (
@@ -76,18 +79,26 @@ export function StatusBar({
           </div>
         ) : (
           // Hint row — chips are buttons. Bare-key chips (?, /, :) work
-          // on every platform because the underlying keys exist on
-          // on-screen keyboards too. Modifier-based chips (⌃/⌥) hide
-          // on touch — a tap couldn't simulate a Ctrl-modified key
-          // event for the same handler, and the labels read as noise
-          // without a physical modifier key. The actions are still
-          // reachable by typing the underlying command (e.g. `theme`,
-          // `matrix`, `clear`).
+          // on every platform. On touch we still surface the modifier-
+          // backed actions (recall/palette/theme/gui/matrix/clear) but
+          // drop the meaningless ⌃/⌥ glyphs and render them as plain
+          // bracketed labels so users get one-tap access to the same
+          // functionality desktop users get from the keyboard. Strip is
+          // horizontally scrollable for narrow screens.
           <div className="flex items-center gap-x-2 sm:gap-x-3 overflow-x-auto scrollbar-hide whitespace-nowrap flex-1 min-w-0">
             <Hint chip="?" label="help" onTap={actions.help} />
             <Hint chip="/" label="search" onTap={actions.search} />
             <Hint chip=":" label="cmd" onTap={actions.cmd} />
-            {!isTouchDevice && (
+            {isTouchDevice ? (
+              <>
+                <TouchChip label="recall" onTap={actions.recall} />
+                <TouchChip label="palette" onTap={actions.palette} />
+                <TouchChip label="theme" onTap={actions.cycleTheme} />
+                <TouchChip label="gui" onTap={actions.toGui} />
+                <TouchChip label="matrix" onTap={actions.matrix} />
+                <TouchChip label="clear" onTap={actions.clear} />
+              </>
+            ) : (
               <>
                 <Hint chip={`${ctrlKey}R`} label="recall" onTap={actions.recall} />
                 <Hint chip={`${ctrlKey}K`} label="palette" onTap={actions.palette} />
@@ -142,4 +153,21 @@ function Hint({
     );
   }
   return <span className="inline-flex items-center gap-1 text-tui-muted">{inner}</span>;
+}
+
+/** Touch-device variant of Hint — no kbd glyph (modifier keys don't
+ *  exist on phones), just a `[label]` chip that fires the same action.
+ *  Slightly bigger tap target than the desktop hint so it's reachable
+ *  on a small screen. */
+function TouchChip({ label, onTap }: { label: string; onTap: () => void }) {
+  return (
+    <button
+      type="button"
+      onClick={onTap}
+      aria-label={label}
+      className="inline-flex items-center rounded-sm border border-tui-accent-dim/40 px-1.5 py-[1px] text-tui-muted hover:text-terminal-bright-green hover:border-terminal-bright-green/60 active:bg-terminal-bright-green/10 focus-visible:outline-none focus-visible:text-terminal-bright-green focus-visible:border-terminal-bright-green transition-colors"
+    >
+      {label}
+    </button>
+  );
 }


### PR DESCRIPTION
## Summary

Two mobile-only fixes, observed on a real phone:

### 1. Soft keyboard hides the input + status bar
Root cause: outer shells used \`h-screen\` (= \`100vh\`), which is pinned to the full page height even when the OS keyboard opens. The prompt input + chip strip ended up behind the keyboard's accessory bar (suggestions, payment autofill, etc.). Fixed by switching to \`h-dvh\` (dynamic viewport height) — the layout now shrinks with the visual viewport and lifts the input + status bar above the keyboard automatically.

- \`client/src/components/Terminal.tsx\` (3 sites: loading, error, main)
- \`client/src/components/TerminalView.tsx\`

### 2. Status-bar chips unreachable on touch
The modifier-key chips (recall / palette / theme / gui / matrix / clear) were gated behind \`!isTouchDevice\` because their \`⌃R\` / \`⌥T\` glyphs are meaningless on mobile. But the underlying \`onTap\` handlers work fine via tap — so hiding the chips also hid the actions. Touch users were stuck with only \`?\`, \`/\`, \`:\` (3 chips total) and no shortcut path to palette / theme / matrix / clear.

New \`<TouchChip>\` variant renders each as a tappable \`[label]\` bracketed button on touch devices — no kbd glyph, slightly bigger tap target. Strip is already \`overflow-x-auto\` so it scrolls horizontally on narrow screens.

Plus: \`pb-[max(0.25rem,env(safe-area-inset-bottom))]\` on the status bar so the chips don't sit under the iPhone home indicator.

## Test plan

- [ ] Open on iPhone (Safari + Chrome): tap input, verify the keyboard pushes the input + chip strip up rather than covering them
- [ ] Tap each chip in the strip — verify all 9 actions fire (help / search / cmd / recall / palette / theme / gui / matrix / clear)
- [ ] Verify horizontal scroll works on the chip strip when it overflows
- [ ] Verify desktop look is unchanged (chips still show \`⌃R\` / \`⌥T\` glyphs, no extra bottom padding)

🤖 Generated with [Claude Code](https://claude.com/claude-code)