### PR TITLE
sync: mobile keyboard reflow + reachable chips on touch (PR #12 → main)

### DIFF
--- a/client/src/components/Terminal.tsx
+++ b/client/src/components/Terminal.tsx
@@ -615,7 +615,7 @@ function Terminal({ onSwitchToGUI }: TerminalProps) {
   // Render loading or error states
   if (isLoading) {
     return (
-      <div className="terminal-glow terminal-scanlines relative w-full h-screen bg-terminal-black">
+      <div className="terminal-glow terminal-scanlines relative w-full h-dvh bg-terminal-black">
         <div className="flex items-center justify-center h-full">
           <div className="text-terminal-green">
             <div className="mb-4">{uiText.loading.text}</div>
@@ -628,7 +628,7 @@ function Terminal({ onSwitchToGUI }: TerminalProps) {
 
   if (error) {
     return (
-      <div className="terminal-glow terminal-scanlines relative w-full h-screen bg-terminal-black">
+      <div className="terminal-glow terminal-scanlines relative w-full h-dvh bg-terminal-black">
         <div className="flex items-center justify-center h-full">
           <div className="text-terminal-red">
             <div className="mb-4">{uiText.loading.error}:</div>
@@ -641,7 +641,10 @@ function Terminal({ onSwitchToGUI }: TerminalProps) {
   }
 
   return (
-    <div className="terminal-glow terminal-scanlines relative w-full h-screen bg-terminal-black">
+    // h-dvh so the layout shrinks with the visual viewport when the
+    // mobile soft keyboard opens — h-screen (100vh) is fixed to the
+    // page height and lets the keyboard cover the input + status bar.
+    <div className="terminal-glow terminal-scanlines relative w-full h-dvh bg-terminal-black">
       {/* Shared film-grain atmosphere — also used by the GUI so both
            views share one noise floor. Paused on reduced-motion. */}
       <div className="film-grain" aria-hidden="true" />

--- a/client/src/components/TerminalView.tsx
+++ b/client/src/components/TerminalView.tsx
@@ -12,7 +12,7 @@ function TerminalView() {
       animate={{ opacity: 1 }}
       exit={{ opacity: 0 }}
       transition={{ duration: 0.4 }}
-      className="w-full h-screen overflow-hidden relative"
+      className="w-full h-dvh overflow-hidden relative"
     >
       <Terminal onSwitchToGUI={() => switchTo('gui')} />
 

--- a/client/src/components/tui/StatusBar.tsx
+++ b/client/src/components/tui/StatusBar.tsx
@@ -56,7 +56,10 @@ export function StatusBar({
     <footer
       role="toolbar"
       aria-label="terminal hints"
-      className="flex-shrink-0 border-t border-tui-accent-dim/30 bg-terminal-black px-2 sm:px-3 py-1 font-mono text-[10px] sm:text-[11px] leading-tight"
+      // pb adds safe-area for iPhones with a home bar so chips don't
+      // sit under the indicator. With h-dvh on the outer shell, the
+      // strip lifts above the soft keyboard automatically when it opens.
+      className="flex-shrink-0 border-t border-tui-accent-dim/30 bg-terminal-black px-2 sm:px-3 py-1 pb-[max(0.25rem,env(safe-area-inset-bottom))] font-mono text-[10px] sm:text-[11px] leading-tight"
     >
       <div className="max-w-4xl flex items-center gap-x-3">
         {mode === 'search' ? (
@@ -76,18 +79,26 @@ export function StatusBar({
           </div>
         ) : (
           // Hint row — chips are buttons. Bare-key chips (?, /, :) work
-          // on every platform because the underlying keys exist on
-          // on-screen keyboards too. Modifier-based chips (⌃/⌥) hide
-          // on touch — a tap couldn't simulate a Ctrl-modified key
-          // event for the same handler, and the labels read as noise
-          // without a physical modifier key. The actions are still
-          // reachable by typing the underlying command (e.g. `theme`,
-          // `matrix`, `clear`).
+          // on every platform. On touch we still surface the modifier-
+          // backed actions (recall/palette/theme/gui/matrix/clear) but
+          // drop the meaningless ⌃/⌥ glyphs and render them as plain
+          // bracketed labels so users get one-tap access to the same
+          // functionality desktop users get from the keyboard. Strip is
+          // horizontally scrollable for narrow screens.
           <div className="flex items-center gap-x-2 sm:gap-x-3 overflow-x-auto scrollbar-hide whitespace-nowrap flex-1 min-w-0">
             <Hint chip="?" label="help" onTap={actions.help} />
             <Hint chip="/" label="search" onTap={actions.search} />
             <Hint chip=":" label="cmd" onTap={actions.cmd} />
-            {!isTouchDevice && (
+            {isTouchDevice ? (
+              <>
+                <TouchChip label="recall" onTap={actions.recall} />
+                <TouchChip label="palette" onTap={actions.palette} />
+                <TouchChip label="theme" onTap={actions.cycleTheme} />
+                <TouchChip label="gui" onTap={actions.toGui} />
+                <TouchChip label="matrix" onTap={actions.matrix} />
+                <TouchChip label="clear" onTap={actions.clear} />
+              </>
+            ) : (
               <>
                 <Hint chip={`${ctrlKey}R`} label="recall" onTap={actions.recall} />
                 <Hint chip={`${ctrlKey}K`} label="palette" onTap={actions.palette} />
@@ -142,4 +153,21 @@ function Hint({
     );
   }
   return <span className="inline-flex items-center gap-1 text-tui-muted">{inner}</span>;
+}
+
+/** Touch-device variant of Hint — no kbd glyph (modifier keys don't
+ *  exist on phones), just a `[label]` chip that fires the same action.
+ *  Slightly bigger tap target than the desktop hint so it's reachable
+ *  on a small screen. */
+function TouchChip({ label, onTap }: { label: string; onTap: () => void }) {
+  return (
+    <button
+      type="button"
+      onClick={onTap}
+      aria-label={label}
+      className="inline-flex items-center rounded-sm border border-tui-accent-dim/40 px-1.5 py-[1px] text-tui-muted hover:text-terminal-bright-green hover:border-terminal-bright-green/60 active:bg-terminal-bright-green/10 focus-visible:outline-none focus-visible:text-terminal-bright-green focus-visible:border-terminal-bright-green transition-colors"
+    >
+      {label}
+    </button>
+  );
 }


### PR DESCRIPTION
Cherry-picks the single commit from PR #12 (\`personal\`) into \`main\`. No personal-file touches — clean cherry-pick, same diff as #12.

## What

- \`h-screen\` → \`h-dvh\` so the layout shrinks with the visual viewport when the soft keyboard opens (input + status bar lift above the keyboard accessory bar instead of being covered).
- Status-bar chips for modifier-keyed actions (recall / palette / theme / gui / matrix / clear) now render on touch devices as tappable \`[label]\` chips via a new \`<TouchChip>\` variant. Previously hidden because their \`⌃R\` / \`⌥T\` glyphs were meaningless on mobile, but the underlying \`onTap\` handlers worked — so hiding them also hid the actions.
- Added \`pb-[env(safe-area-inset-bottom)]\` so chips clear the iPhone home indicator.

Files: \`Terminal.tsx\`, \`TerminalView.tsx\`, \`StatusBar.tsx\`. Desktop look unchanged.

## Test plan

- [ ] Open on iPhone (Safari + Chrome): tap input, verify keyboard pushes the input + chip strip up rather than covering them
- [ ] Tap each chip in the strip — verify all 9 actions fire
- [ ] Verify desktop look unchanged (chips still show \`⌃R\` / \`⌥T\` glyphs, no extra bottom padding)

🤖 Generated with [Claude Code](https://claude.com/claude-code)