### PR TITLE
fix(tui): mobile reverse-search chips, matrix rain zoom, floater overlap

### DIFF
--- a/client/src/components/Terminal.tsx
+++ b/client/src/components/Terminal.tsx
@@ -886,6 +886,25 @@ function Terminal({ onSwitchToGUI }: TerminalProps) {
             // (doesn't auto-dismiss on next keypress).
             matrix: toggleMatrix,
             clear: () => clearTerminal(),
+            // Search-mode chip taps — let touch users drive the
+            // reverse-search the same way desktop users drive it
+            // with Ctrl+R / Enter / Tab / Esc.
+            searchNext: () => {
+              setSearchMatchIndex((i) =>
+                searchMatches.length > 0 ? (i + 1) % searchMatches.length : 0,
+              );
+            },
+            searchRun: () => {
+              if (activeSearchMatch) {
+                exitSearchMode(null);
+                setInput('');
+                executeCommand(activeSearchMatch);
+              } else {
+                exitSearchMode('');
+              }
+            },
+            searchEdit: () => exitSearchMode(activeSearchMatch ?? ''),
+            searchCancel: () => exitSearchMode(''),
           }}
         />
       </div>

--- a/client/src/components/TerminalView.tsx
+++ b/client/src/components/TerminalView.tsx
@@ -16,11 +16,13 @@ function TerminalView() {
     >
       <Terminal onSwitchToGUI={() => switchTo('gui')} />
 
-      {/* Floating GUI switch button */}
+      {/* Floating GUI switch button — desktop only. On mobile the
+          `gui` chip in the status bar already covers this, and the
+          floating button overlaps the prompt + chip strip awkwardly. */}
       <motion.button
         onClick={() => switchTo('gui')}
-        className="fixed bottom-5 right-5 z-50 w-10 h-10 rounded-lg bg-zinc-900/80 border border-zinc-700
-                   flex items-center justify-center text-terminal-green/60 hover:text-terminal-green hover:border-terminal-green hover:bg-terminal-green/10
+        className="hidden sm:flex fixed bottom-5 right-5 z-50 w-10 h-10 rounded-lg bg-zinc-900/80 border border-zinc-700
+                   items-center justify-center text-terminal-green/60 hover:text-terminal-green hover:border-terminal-green hover:bg-terminal-green/10
                    transition-colors duration-200 backdrop-blur-sm group"
         whileHover={{ scale: 1.1 }}
         whileTap={{ scale: 0.95 }}

--- a/client/src/components/tui/IdleMatrixRain.tsx
+++ b/client/src/components/tui/IdleMatrixRain.tsx
@@ -72,7 +72,11 @@ export function IdleMatrixRain({ active }: IdleMatrixRainProps) {
     if (!ctx) return;
 
     const isMobile = window.innerWidth < 768;
-    const colWidth = isMobile ? COL_WIDTH * 2 : COL_WIDTH;
+    // Mobile previously used 2× column width (44px / 40px font) which
+    // read as a wall of giant glyphs — too "zoomed in" relative to
+    // screen size. 1.3× keeps the column count low enough for perf
+    // on weaker devices while letting more glyphs share the screen.
+    const colWidth = isMobile ? Math.round(COL_WIDTH * 1.3) : COL_WIDTH;
 
     let w = 0;
     let h = 0;

--- a/client/src/components/tui/StatusBar.tsx
+++ b/client/src/components/tui/StatusBar.tsx
@@ -12,6 +12,13 @@ export interface StatusBarActions {
   toGui: () => void;
   matrix: () => void;
   clear: () => void;
+  /** Search-mode chip handlers. On desktop these duplicate keyboard
+   *  shortcuts (Ctrl+R / Enter / Tab / Esc); on touch they're the only
+   *  way to drive the search since there's no physical keyboard. */
+  searchNext?: () => void;
+  searchRun?: () => void;
+  searchEdit?: () => void;
+  searchCancel?: () => void;
 }
 
 interface StatusBarProps {
@@ -72,10 +79,10 @@ export function StatusBar({
                 ? `${searchInfo.matchIndex + 1}/${searchInfo.matchCount}`
                 : 'no match'}
             </span>
-            <Hint chip={`${ctrlKey}R`} label="next" onTap={actions.recall} />
-            <Hint chip="↵" label="run" />
-            <Hint chip="tab" label="edit" />
-            <Hint chip="esc" label="cancel" />
+            <Hint chip={`${ctrlKey}R`} label="next" onTap={actions.searchNext} />
+            <Hint chip="↵" label="run" onTap={actions.searchRun} />
+            <Hint chip="tab" label="edit" onTap={actions.searchEdit} />
+            <Hint chip="esc" label="cancel" onTap={actions.searchCancel} />
           </div>
         ) : (
           // Hint row — chips are buttons. Bare-key chips (?, /, :) work


### PR DESCRIPTION
Three mobile fixes after the previous pass:

### 1. Reverse-search chips were unclickable on touch
Tapping \`recall\` opens search mode and swaps the StatusBar chips to \`1/100 · ⌃R next · ↵ run · tab edit · esc cancel\`. Only \`next\` had an onTap (and it was wired to \`actions.recall\` — which just re-enters search mode, useless). \`run\` / \`edit\` / \`cancel\` had no handlers at all.

Added \`searchNext\` / \`searchRun\` / \`searchEdit\` / \`searchCancel\` to the StatusBar actions interface. Terminal.tsx wires them to the same \`exitSearchMode\` + index-cycling logic the keyboard handlers already use. Touch users can now drive reverse-search end-to-end with the chips alone.

### 2. Matrix rain too zoomed-in on phones
Mobile branch used \`COL_WIDTH * 2\` (44px columns, 40px font) — wall of giant katakana, out of proportion. Reduced to \`* 1.3\` (~28px / 24px font) so the rain reads right-sized while still keeping the column count low enough for perf on weaker devices.

### 3. Floating GUI-switch button overlapped the prompt + status bar on mobile
\`fixed bottom-5 right-5\` works on desktop but on phones it landed in the strip between the prompt input and the chip strip. Hidden on mobile — the \`gui\` chip in the status bar already covers the same action.

## Test plan

- [ ] Mobile: tap \`recall\`, then tap each search chip in turn — verify next/run/edit/cancel all work
- [ ] Mobile: idle for 30s (or trigger \`matrix\`), verify rain glyph size is reasonable
- [ ] Mobile: confirm no floating GUI button at bottom-right; \`gui\` chip in strip still works
- [ ] Desktop: confirm floating button still appears + works

🤖 Generated with [Claude Code](https://claude.com/claude-code)