### PR TITLE
feat(tui): rainbow command — multi-hue matrix rain

### DIFF
--- a/client/src/components/Terminal.tsx
+++ b/client/src/components/Terminal.tsx
@@ -67,10 +67,12 @@ function Terminal({ onSwitchToGUI }: TerminalProps) {
     onTriggerMatrix: (opts) => {
       setMatrixActive(true);
       setMatrixPersistent(opts?.persist === true);
+      setMatrixRainbow(opts?.rainbow === true);
     },
     onDismissMatrix: () => {
       setMatrixActive(false);
       setMatrixPersistent(false);
+      setMatrixRainbow(false);
     },
   });
 
@@ -92,6 +94,10 @@ function Terminal({ onSwitchToGUI }: TerminalProps) {
   // dismisses on user interaction.
   const [matrixActive, setMatrixActive] = useState(false);
   const [matrixPersistent, setMatrixPersistent] = useState(false);
+  // Rainbow mode — flipped on by the `rainbow` command, cleared on
+  // every dismiss + on Alt+M / chip toggle so plain matrix toggles
+  // never inherit a stale rainbow state.
+  const [matrixRainbow, setMatrixRainbow] = useState(false);
 
   // Persistent silent toggle for Alt+M / the matrix chip. We bypass
   // executeCommand entirely — no prompt echo, no scrollback line, no
@@ -102,9 +108,11 @@ function Terminal({ onSwitchToGUI }: TerminalProps) {
     setMatrixActive((wasActive) => {
       if (wasActive) {
         setMatrixPersistent(false);
+        setMatrixRainbow(false);
         return false;
       }
       setMatrixPersistent(true);
+      setMatrixRainbow(false);
       return true;
     });
   }, []);
@@ -651,7 +659,7 @@ function Terminal({ onSwitchToGUI }: TerminalProps) {
       {/* Idle matrix-rain screensaver — positioned on the outer shell
            (not the scrolling output pane) so it overlays the full
            terminal viewport regardless of scroll position. */}
-      <IdleMatrixRain active={matrixActive} />
+      <IdleMatrixRain active={matrixActive} rainbow={matrixRainbow} />
       <div className="flex flex-col h-full">
         {/* Terminal Header — traffic-light dots keep the retro chrome,
              and the path segment now reflects the Starship-style dir. */}

--- a/client/src/components/tui/IdleMatrixRain.tsx
+++ b/client/src/components/tui/IdleMatrixRain.tsx
@@ -5,6 +5,10 @@ import { getAccentRgb } from '../../config/gui-theme.config';
 interface IdleMatrixRainProps {
   /** When true, the overlay fades in and animates. When false, fades out. */
   active: boolean;
+  /** Rainbow mode — each column gets its own hue distributed across
+   *  the spectrum, animated with a slow drift. Off by default; flipped
+   *  on by the `rainbow` command. */
+  rainbow?: boolean;
 }
 
 const KATAKANA = 'アイウエオカキクケコサシスセソタチツテトナニヌネノハヒフヘホマミムメモヤユヨラリルレロワヲン';
@@ -59,10 +63,12 @@ function randomChar() {
  * Positioned `fixed inset-0 z-30` so it overlays the entire viewport
  * regardless of scroll. Pointer-events: none so clicks fall through.
  */
-export function IdleMatrixRain({ active }: IdleMatrixRainProps) {
+export function IdleMatrixRain({ active, rainbow = false }: IdleMatrixRainProps) {
   const canvasRef = useRef<HTMLCanvasElement>(null);
   const activeRef = useRef(active);
   activeRef.current = active;
+  const rainbowRef = useRef(rainbow);
+  rainbowRef.current = rainbow;
   const prefersReducedMotion = useReducedMotion();
 
   useEffect(() => {
@@ -147,7 +153,13 @@ export function IdleMatrixRain({ active }: IdleMatrixRainProps) {
         return;
       }
 
-      const [r, g, b] = getAccentRgb();
+      const isRainbow = rainbowRef.current;
+      // Theme-coloured baseline; ignored when rainbow mode is on.
+      const [r, g, b] = isRainbow ? [0, 0, 0] : getAccentRgb();
+      // Rainbow drift — slowly rotate the hue assignment so columns
+      // breathe through the spectrum instead of being statically
+      // assigned. ~0.02 hue/ms ≈ full cycle every ~18s.
+      const hueOffset = isRainbow ? (now * 0.02) % 360 : 0;
       ctx.clearRect(0, 0, w, h);
       ctx.font = `${colWidth - 4}px 'JetBrains Mono', 'Fira Code', monospace`;
       ctx.textAlign = 'center';
@@ -181,6 +193,13 @@ export function IdleMatrixRain({ active }: IdleMatrixRainProps) {
 
         const colX = i * colWidth + colWidth / 2;
         const trailLen = 18;
+        // Per-column hue when rainbow is on — distributed evenly across
+        // the spectrum so adjacent columns are visibly different. The
+        // hueOffset above adds a slow drift on top of the per-column
+        // assignment.
+        const colHue = isRainbow
+          ? (i * (360 / Math.max(columns.length, 1)) + hueOffset) % 360
+          : 0;
 
         for (let j = 0; j < trailLen; j++) {
           const charY = col.y - j * (colWidth - 2);
@@ -195,13 +214,15 @@ export function IdleMatrixRain({ active }: IdleMatrixRainProps) {
 
           // Uniform fade — j=0 is the brightest point on the trail
           // ramp (≈ 0.5 × opacity) but no longer gets a special "head"
-          // boost. The boosted head used to punch much brighter than
-          // the surrounding glyphs which read as inconsistent /
-          // distracting; a continuous ramp is calmer and easier on
-          // any theme.
+          // boost.
           const trailOpacity = (1 - j / trailLen) * 0.5 * opacity;
           if (trailOpacity < 0.002) continue;
-          ctx.fillStyle = `rgba(${r}, ${g}, ${b}, ${trailOpacity})`;
+          if (isRainbow) {
+            // hsla — saturated and bright so glyphs pop on black.
+            ctx.fillStyle = `hsla(${colHue}, 100%, 60%, ${trailOpacity})`;
+          } else {
+            ctx.fillStyle = `rgba(${r}, ${g}, ${b}, ${trailOpacity})`;
+          }
           ctx.fillText(ch, colX, charY);
         }
       }

--- a/client/src/hooks/useTerminal.tsx
+++ b/client/src/hooks/useTerminal.tsx
@@ -38,7 +38,7 @@ export interface UseTerminalProps {
    *  presses); omit / pass `false` for the default one-shot summon
    *  (any input dismisses). Terminal.tsx maps this to setMatrixActive
    *  + setMatrixPersistent. */
-  onTriggerMatrix?: (opts?: { persist?: boolean }) => void;
+  onTriggerMatrix?: (opts?: { persist?: boolean; rainbow?: boolean }) => void;
   /** Called by `matrix off` to explicitly dismiss + clear the
    *  persistent flag. */
   onDismissMatrix?: () => void;
@@ -449,6 +449,7 @@ const COMMAND_REGISTRY: CommandMetadata[] = [
   { name: 'coffee', description: 'Brew a caffeinated ascii cup', category: 'hidden', hidden: true },
   { name: 'sudo', description: 'A pleasant refusal', category: 'hidden', hidden: true, argsHint: '<anything>' },
   { name: 'matrix', description: 'Trigger the idle screensaver on demand', category: 'hidden', hidden: true },
+  { name: 'rainbow', description: 'Rainbow-coloured matrix rain — any key dismisses', category: 'hidden', hidden: true },
   { name: 'konami', description: 'Cycle color theme with a flash', category: 'hidden', hidden: true },
   { name: 'rm', description: 'Tread carefully', category: 'hidden', hidden: true, argsHint: '-rf /' },
   // `o N` / `g N` — vim-motion link open. The handler reads the
@@ -2437,6 +2438,22 @@ export function useTerminal({ portfolioData, onSwitchToGUI, onTriggerMatrix, onD
     }
   }, [addLine, onTriggerMatrix, onDismissMatrix]);
 
+  /** Rainbow-mode matrix rain. Same wiring as `matrix` (non-persistent
+   *  — any keypress dismisses) but with rainbow-coloured columns. The
+   *  rainbow flag is set on onTriggerMatrix so the rain renders in
+   *  HSL-spectrum hues instead of the active theme accent. */
+  const showRainbow = useCallback(() => {
+    if (!onTriggerMatrix) {
+      addLine('rainbow rain: not available right now.', 'text-tui-accent-dim');
+      return;
+    }
+    addLine(
+      '// rainbow — taste the rainbow. any key dismisses.',
+      'text-terminal-bright-green',
+    );
+    onTriggerMatrix({ persist: false, rainbow: true });
+  }, [addLine, onTriggerMatrix]);
+
   const showStats = useCallback(async () => {
     // Fetch the live pypi-stats.json; same source as the GUI hero.
     let pypi: PyPIStatsData | null = null;
@@ -2722,6 +2739,9 @@ export function useTerminal({ portfolioData, onSwitchToGUI, onTriggerMatrix, onD
         }
         break;
       }
+      case 'rainbow':
+        showRainbow();
+        break;
       case 'konami':
         showKonami();
         break;
@@ -2826,7 +2846,7 @@ export function useTerminal({ portfolioData, onSwitchToGUI, onTriggerMatrix, onD
         );
         setLastExitCode(127);
     }
-  }, [addLine, addNode, showHelp, openResumePdf, showWelcomeMessage, showAbout, showSkills, showExperience, showEducation, showProjects, showPersonalProjects, showContact, showPublications, showTimeline, showSearch, showTheme, showWhoAmI, listCommands, showCat, showNeofetch, showReplicate, showHistory, clearTerminal, showGenericSection, showQuote, showCoffee, showSudo, showMatrix, showKonami, showStats, showRmRf, linkRegistry, portfolioData, onSwitchToGUI, currentDir]);
+  }, [addLine, addNode, showHelp, openResumePdf, showWelcomeMessage, showAbout, showSkills, showExperience, showEducation, showProjects, showPersonalProjects, showContact, showPublications, showTimeline, showSearch, showTheme, showWhoAmI, listCommands, showCat, showNeofetch, showReplicate, showHistory, clearTerminal, showGenericSection, showQuote, showCoffee, showSudo, showMatrix, showRainbow, showKonami, showStats, showRmRf, linkRegistry, portfolioData, onSwitchToGUI, currentDir]);
 
   const navigateHistory = useCallback((direction: 'up' | 'down') => {
     if (commandHistory.length === 0) return currentInput;


### PR DESCRIPTION
## Summary

New \`rainbow\` command — summons the matrix-rain overlay in spectrum colours instead of the active theme accent. Non-persistent (any keypress dismisses), same as the default \`matrix\` command.

## Implementation

- **\`IdleMatrixRain.tsx\`** — optional \`rainbow\` prop. When true, each column gets its own hue distributed evenly across 360°, with a slow drift (\`now * 0.02 % 360\`) layered on top so columns breathe through the spectrum. Uses \`hsla(hue, 100%, 60%, alpha)\` for vibrant glyphs; bypasses \`getAccentRgb()\` entirely so theme switching doesn't fight it.
- **\`useTerminal.tsx\`** — new \`showRainbow\` callback fires \`onTriggerMatrix({ persist: false, rainbow: true })\`. New \`rainbow\` entry in \`COMMAND_REGISTRY\` (hidden, like \`matrix\`).
- **\`Terminal.tsx\`** — \`matrixRainbow\` state mirrors the rainbow flag from trigger opts. Cleared on every dismiss + on the Alt+M / chip toggle path so a plain \`matrix\` toggle never inherits a stale rainbow state.

## Test plan

- [ ] Type \`rainbow\` → rainbow rain appears, any keypress dismisses
- [ ] Type \`matrix\` → normal theme-coloured rain (rainbow flag cleared)
- [ ] Switch themes mid-rainbow — rainbow stays rainbow (doesn't snap to theme)
- [ ] Trigger via mobile chip / Alt+M after a \`rainbow\` — should give plain matrix, not rainbow

🤖 Generated with [Claude Code](https://claude.com/claude-code)