### PR TITLE
feat: sync engine fixes from personal + workflow polish

### DIFF
--- a/.github/workflows/deploy.yaml
+++ b/.github/workflows/deploy.yaml
@@ -123,6 +123,10 @@ jobs:
       env:
         VITE_BASE_PATH: ${{ steps.compute-base-path.outputs.BASE_PATH }}
         VITE_SITE_URL: ${{ steps.compute-base-path.outputs.SITE_URL }}
+        # scripts/fetch-stats.js needs auth for /search/code (any token
+        # works) and /traffic/* (owner-only, will gracefully no-op if the
+        # workflow's GITHUB_TOKEN lacks `administration: read`).
+        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
 
     - name: ⚙️  Configure GitHub Pages

--- a/.github/workflows/sync-main-to-personal.yaml
+++ b/.github/workflows/sync-main-to-personal.yaml
@@ -73,7 +73,11 @@ jobs:
       if: steps.check.outputs.ahead != '0'
       id: merge
       run: |
-        BRANCH="sync/main-to-personal-${{ github.run_number }}"
+        # Stable branch name — every workflow run force-pushes to the same
+        # branch so multiple main pushes coalesce into ONE rolling sync PR
+        # instead of stacking up. (The previous run-number'd name created
+        # a fresh PR on every run.)
+        BRANCH="sync/main-to-personal"
         echo "branch=$BRANCH" >> $GITHUB_OUTPUT
         git checkout -b "$BRANCH"
 
@@ -174,9 +178,14 @@ jobs:
           gh pr create \
             --base personal \
             --head "$BRANCH" \
-            --title "🔄 Sync main → personal (${AHEAD} commit$([ "$AHEAD" = "1" ] || echo s))" \
+            --title "🔄 Sync main → personal" \
             --body "$BODY"
         else
-          gh pr edit "$EXISTING" --body "$BODY"
-          echo "Updated existing PR #${EXISTING}"
+          # Force-push from the merge step has already updated the diff;
+          # we just refresh the PR body so the commit count + changelog
+          # in the description stay current.
+          gh pr edit "$EXISTING" \
+            --title "🔄 Sync main → personal (${AHEAD} commit$([ "$AHEAD" = "1" ] || echo s) ahead)" \
+            --body "$BODY"
+          echo "Updated existing PR #${EXISTING} (now ${AHEAD} commit$([ "$AHEAD" = "1" ] || echo s) ahead)"
         fi

--- a/client/src/components/Terminal.tsx
+++ b/client/src/components/Terminal.tsx
@@ -894,6 +894,25 @@ function Terminal({ onSwitchToGUI }: TerminalProps) {
             // (doesn't auto-dismiss on next keypress).
             matrix: toggleMatrix,
             clear: () => clearTerminal(),
+            // Search-mode chip taps — let touch users drive the
+            // reverse-search the same way desktop users drive it
+            // with Ctrl+R / Enter / Tab / Esc.
+            searchNext: () => {
+              setSearchMatchIndex((i) =>
+                searchMatches.length > 0 ? (i + 1) % searchMatches.length : 0,
+              );
+            },
+            searchRun: () => {
+              if (activeSearchMatch) {
+                exitSearchMode(null);
+                setInput('');
+                executeCommand(activeSearchMatch);
+              } else {
+                exitSearchMode('');
+              }
+            },
+            searchEdit: () => exitSearchMode(activeSearchMatch ?? ''),
+            searchCancel: () => exitSearchMode(''),
           }}
         />
       </div>

--- a/client/src/components/TerminalView.tsx
+++ b/client/src/components/TerminalView.tsx
@@ -16,11 +16,13 @@ function TerminalView() {
     >
       <Terminal onSwitchToGUI={() => switchTo('gui')} />
 
-      {/* Floating GUI switch button */}
+      {/* Floating GUI switch button — desktop only. On mobile the
+          `gui` chip in the status bar already covers this, and the
+          floating button overlaps the prompt + chip strip awkwardly. */}
       <motion.button
         onClick={() => switchTo('gui')}
-        className="fixed bottom-5 right-5 z-50 w-10 h-10 rounded-lg bg-zinc-900/80 border border-zinc-700
-                   flex items-center justify-center text-terminal-green/60 hover:text-terminal-green hover:border-terminal-green hover:bg-terminal-green/10
+        className="hidden sm:flex fixed bottom-5 right-5 z-50 w-10 h-10 rounded-lg bg-zinc-900/80 border border-zinc-700
+                   items-center justify-center text-terminal-green/60 hover:text-terminal-green hover:border-terminal-green hover:bg-terminal-green/10
                    transition-colors duration-200 backdrop-blur-sm group"
         whileHover={{ scale: 1.1 }}
         whileTap={{ scale: 0.95 }}

--- a/client/src/components/gui/GUIPortfolio.tsx
+++ b/client/src/components/gui/GUIPortfolio.tsx
@@ -29,7 +29,7 @@ import RacerGame from './RacerGame';
 import HelpSheet from './HelpSheet';
 import ReplicateSheet from './ReplicateSheet';
 
-const SECTIONS = ['skills', 'experience', 'work', 'projects', 'education', 'publication', 'contact'];
+const SECTIONS = ['about', 'skills', 'experience', 'work', 'projects', 'education', 'publication', 'contact'];
 
 export default function GUIPortfolio() {
   const [activeSection, setActiveSection] = useState<string>('');

--- a/client/src/components/gui/Navbar.tsx
+++ b/client/src/components/gui/Navbar.tsx
@@ -8,7 +8,7 @@ import ReplicateButton from './ReplicateButton';
 import { toggleFullscreen } from '../../lib/fullscreen';
 import * as audio from '../../lib/audio';
 
-const NAV_SECTIONS = ['skills', 'experience', 'work', 'projects', 'education', 'publication', 'contact'];
+const NAV_SECTIONS = ['about', 'skills', 'experience', 'work', 'projects', 'education', 'publication', 'contact'];
 
 const SOCIAL_CODES: Record<string, string> = {
   LinkedIn: 'IN',
@@ -29,6 +29,7 @@ export default function Navbar({ activeSection, data }: NavbarProps) {
   const { switchTo } = useViewMode();
   const [visible, setVisible] = useState(false);
   const [mobileOpen, setMobileOpen] = useState(false);
+  const [hasLogo, setHasLogo] = useState(true);
 
   const cv = data?.cv;
   const monogram = cv?.name
@@ -44,8 +45,15 @@ export default function Navbar({ activeSection, data }: NavbarProps) {
   }, []);
 
   const scrollToSection = (id: string) => {
-    document.getElementById(id)?.scrollIntoView({ behavior: 'smooth' });
     setMobileOpen(false);
+    // Delay scroll so the menu close animation settles first
+    setTimeout(() => {
+      const el = document.getElementById(id);
+      if (!el) return;
+      const navHeight = 56; // h-14 = 3.5rem = 56px
+      const top = el.getBoundingClientRect().top + window.scrollY - navHeight;
+      window.scrollTo({ top, behavior: 'smooth' });
+    }, 350);
   };
 
   return (
@@ -73,9 +81,11 @@ export default function Navbar({ activeSection, data }: NavbarProps) {
 
             {/* Center: monogram + dot indicators (desktop) */}
             <div className="hidden sm:flex items-center gap-4">
-              {monogram && (
+              {hasLogo ? (
+                <img src="/logo.png" alt={monogram || 'Logo'} className="h-6 w-6 mr-4 object-contain" onError={() => setHasLogo(false)} />
+              ) : monogram ? (
                 <span className="text-white font-display text-lg tracking-wider mr-4">{monogram}</span>
-              )}
+              ) : null}
               {NAV_SECTIONS.map((section) => (
                 <button
                   key={section}
@@ -96,6 +106,13 @@ export default function Navbar({ activeSection, data }: NavbarProps) {
                 </button>
               ))}
             </div>
+
+            {/* Mobile center logo/monogram */}
+            {hasLogo ? (
+              <img src="/logo.png" alt={monogram || 'Logo'} className="sm:hidden h-6 w-6 object-contain" onError={() => setHasLogo(false)} />
+            ) : monogram ? (
+              <span className="sm:hidden text-white font-display text-lg tracking-wider">{monogram}</span>
+            ) : null}
 
             {/* Mobile hamburger */}
             <button

--- a/client/src/components/gui/ProfessionalProjectsSection.tsx
+++ b/client/src/components/gui/ProfessionalProjectsSection.tsx
@@ -2,7 +2,7 @@ import { useRef, useState, useMemo, useEffect } from 'react';
 import { motion, useInView, AnimatePresence } from 'framer-motion';
 import type { PortfolioData, Project } from '../../../../shared/schema';
 import SectionWrapper from './SectionWrapper';
-import { renderGuiMarkdown, extractMetric } from '../../lib/guiMarkdown';
+import { renderGuiMarkdown } from '../../lib/guiMarkdown';
 import ScrambleText from './ScrambleText';
 
 interface ProfessionalProjectsSectionProps {

--- a/client/src/components/tui/IdleMatrixRain.tsx
+++ b/client/src/components/tui/IdleMatrixRain.tsx
@@ -78,7 +78,11 @@ export function IdleMatrixRain({ active, rainbow = false }: IdleMatrixRainProps)
     if (!ctx) return;
 
     const isMobile = window.innerWidth < 768;
-    const colWidth = isMobile ? COL_WIDTH * 2 : COL_WIDTH;
+    // Mobile previously used 2× column width (44px / 40px font) which
+    // read as a wall of giant glyphs — too "zoomed in" relative to
+    // screen size. 1.3× keeps the column count low enough for perf
+    // on weaker devices while letting more glyphs share the screen.
+    const colWidth = isMobile ? Math.round(COL_WIDTH * 1.3) : COL_WIDTH;
 
     let w = 0;
     let h = 0;

--- a/client/src/components/tui/StatusBar.tsx
+++ b/client/src/components/tui/StatusBar.tsx
@@ -12,6 +12,13 @@ export interface StatusBarActions {
   toGui: () => void;
   matrix: () => void;
   clear: () => void;
+  /** Search-mode chip handlers. On desktop these duplicate keyboard
+   *  shortcuts (Ctrl+R / Enter / Tab / Esc); on touch they're the only
+   *  way to drive the search since there's no physical keyboard. */
+  searchNext?: () => void;
+  searchRun?: () => void;
+  searchEdit?: () => void;
+  searchCancel?: () => void;
 }
 
 interface StatusBarProps {
@@ -72,10 +79,10 @@ export function StatusBar({
                 ? `${searchInfo.matchIndex + 1}/${searchInfo.matchCount}`
                 : 'no match'}
             </span>
-            <Hint chip={`${ctrlKey}R`} label="next" onTap={actions.recall} />
-            <Hint chip="↵" label="run" />
-            <Hint chip="tab" label="edit" />
-            <Hint chip="esc" label="cancel" />
+            <Hint chip={`${ctrlKey}R`} label="next" onTap={actions.searchNext} />
+            <Hint chip="↵" label="run" onTap={actions.searchRun} />
+            <Hint chip="tab" label="edit" onTap={actions.searchEdit} />
+            <Hint chip="esc" label="cancel" onTap={actions.searchCancel} />
           </div>
         ) : (
           // Hint row — chips are buttons. Bare-key chips (?, /, :) work


### PR DESCRIPTION
## Summary

The first auto-sync (PR #19) revealed that `personal` had ~62 lines of engine fixes that never made it back to `main` via the legacy `sync-X-to-main` pattern. Pulling them back now so main is content-equivalent to personal on engine paths.

After this lands, both branches are in sync content-wise; the new auto-sync flow (`main → personal`) keeps them aligned with no manual cherry-picking.

## Engine fixes brought from personal

- **`Terminal.tsx`, `TerminalView.tsx`, `StatusBar.tsx`, `IdleMatrixRain.tsx`** — mobile-fixes-2 (PR #14): search-chip `onTap` handlers, mobile reverse-search hints, matrix-rain mobile column-width.
- **`Navbar.tsx`** — `hasLogo` state + mobile center logo, `scrollToSection` with menu-close delay, `'about'` added to `NAV_SECTIONS`.
- **`GUIPortfolio.tsx`** — `'about'` added to `SECTIONS` array.
- **`ProfessionalProjectsSection.tsx`** — section-wrapper tweak.

## Workflow polish (caught while auditing the first sync run)

### 1. `deploy.yaml`: pass `GITHUB_TOKEN` to the build step

Without it, `scripts/fetch-stats.js` ran **unauthenticated (60 req/hr)** in CI and got `401` on every `/search/code` call — `orphan_derivatives` stayed at `0` in CI even though local runs detect 35. Logs you shared earlier:

\`\`\`
auth: unauthenticated (60 req/hr)
⚠️  code search "formatExperiencePeriod" unavailable (401)
⚠️  code search "useURLCommand" unavailable (401)
⚠️  code search "getCollapsibleId" unavailable (401)
\`\`\`

Now the workflow's repo-scoped token is exposed via `env: GITHUB_TOKEN: \${{ secrets.GITHUB_TOKEN }}`. Code search authenticates immediately. (Traffic API still requires `administration: read` which the default workflow token doesn't have, so it gracefully no-ops via the existing `tryFetch` wrapper.)

### 2. `sync-main-to-personal.yaml`: stable branch name

You asked: *"if I push 5 changes to main, will it create 5 PRs or coalesce?"*

The answer **was 5 PRs** — the old branch name was `sync/main-to-personal-\${{ github.run_number }}` so every run created a fresh branch and a fresh PR. Now it's a stable `sync/main-to-personal` branch — every run force-pushes to it, the existing-PR check finds and updates the rolling PR (title/body refresh, diff auto-updates from the force-push). **One open PR at a time, regardless of how many pushes come in.**

## Test plan

- [ ] After merge, the auto-sync workflow fires on the merge commit and opens a sync PR to personal — should be near-empty since both branches now have the same engine content.
- [ ] On the next personal deploy, `showcase` headline shows the proper orphan count (no more 401s, code search authenticates).
- [ ] Push a follow-up engine commit to main, verify the sync PR UPDATES instead of opening a second one.

🤖 Generated with [Claude Code](https://claude.com/claude-code)