### PR TITLE
docs: reposition as drift-killer — one YAML, resume + portfolio in sync

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -21,7 +21,7 @@ Have an idea for a new feature? [Open a feature request](https://github.com/subh
 
 - A clear description of the feature
 - Why it would be useful
-- How it aligns with the template's goals (ease of use, zero-code deployment)
+- How it aligns with the template's goals (single source of truth, ease of use, zero-code deployment, terminal/GUI mode parity)
 - Examples or mockups (if applicable)
 
 ### Improving Documentation

--- a/FUTURE_ENHANCEMENTS.md
+++ b/FUTURE_ENHANCEMENTS.md
@@ -350,8 +350,8 @@ sections: z.object({
 
 Custom fields are fully supported with automatic compatibility handling:
 
-1. **Web Interface**: Custom fields are preserved in `resume.json` and accessible in the terminal portfolio
-2. **Terminal Display**: Custom fields automatically render in terminal portfolio via dynamic field renderer
+1. **Web Interface**: Custom fields are preserved in `resume.json` and surface in both terminal and GUI modes
+2. **Terminal Display**: Custom fields automatically render in terminal mode via dynamic field renderer
 3. **PDF Generation**: Custom fields are automatically stripped by `scripts/generate-resume.js` before passing to RenderCV
 4. **Schema Validation**: Zod schemas use `.passthrough()` to accept any extra fields
 5. **Backward Compatibility**: RenderCV's strict Pydantic schema doesn't break the build
@@ -365,7 +365,7 @@ This "best of both worlds" approach means:
 **Benefits Achieved**:
 
 - ✅ Users can add custom fields to any entry (profile_url, tech_stack, gpa, etc.)
-- ✅ Custom fields automatically display in terminal interface (no hardcoding needed)
+- ✅ Custom fields automatically display in terminal mode (no hardcoding needed); GUI mode reads them from the same JSON
 - ✅ Type-aware rendering makes data more readable and interactive
 - ✅ Support for non-traditional career paths (remote workers, freelancers)
 - ✅ Better alignment with RenderCV's philosophy of minimal requirements

--- a/MAINTAINER_GUIDE.md
+++ b/MAINTAINER_GUIDE.md
@@ -66,6 +66,8 @@ npm run dev                                # site renders with YOUR data
 
 The hydrated files are gitignored on every branch except `personal`, so they can't accidentally be committed.
 
+> **Smoke-test both modes.** Terminal mode and GUI mode render from the same `resume.json`. After any engine change that touches data shape, rendering, or the splash flow, hit both: type `terminal` (or default-load) for terminal mode, then click the splash GUI toggle (or visit `/#gui`) for GUI mode. A change that breaks parity is a regression.
+
 ### D. Pull pending engine changes into personal manually (if the auto-sync PR isn't open yet)
 
 ```bash

--- a/README.md
+++ b/README.md
@@ -1,6 +1,8 @@
 # 🖥️ Portfolio Template
 
-> Create your own interactive portfolio in minutes — terminal mode + editorial GUI mode, one `resume.yaml`, deployed to GitHub Pages with zero code.
+### One YAML. Resume + portfolio. Always in sync.
+
+Stop maintaining your resume and portfolio site in parallel. `resume.yaml` is the single source of truth — the same file emits a PDF resume **and** a multi-mode portfolio site (splash → terminal → editorial GUI). Update once; both stay in sync. Use `show_on_resume` to control which entries appear where.
 
 **Live Demo:** [subhayu99.github.io](https://subhayu99.github.io)
 
@@ -29,21 +31,18 @@ This repository uses a **dual-branch strategy**:
 
 ## ✨ Features
 
-- 🎨 **Beautiful Terminal UI** - Retro-style terminal interface with multiple themes
-- 📱 **Fully Responsive** - Works perfectly on desktop, tablet, and mobile
-- 🚀 **Zero-Code Setup** - Use visual resume builder, no programming needed
-- 🤖 **AI Resume Converter** - Convert existing resumes to YAML with AI (built-in!)
-- ⚡ **Lightning Fast** - Built with React and Vite for optimal performance
-- 📄 **Auto-Generated PDF** - Your resume automatically converts to downloadable PDF
-- 🎭 **Multiple Themes** - Matrix, Blue, Purple, Amber, Red, and more
-- 🔍 **Smart Search** - Search across all your content instantly
-- 📊 **Interactive Commands** - Explore your portfolio through terminal commands
-- 💾 **PWA Support** - Installable as a progressive web app with offline capabilities
-- 🔒 **Secure** - Built-in XSS protection and Content Security Policy
-- ♿ **Accessible** - ARIA labels and keyboard navigation support
-- 🔄 **Auto-Deploy** - Push changes to GitHub, site updates automatically
-- 🎨 **Custom Fields Support** - Add any custom fields to personalize your resume beyond the standard schema
-- 📂 **Dynamic Sections** - Create custom sections (certifications, awards, etc.) that become terminal commands automatically
+- 📄 **Single Source of Truth** - `resume.yaml` drives a PDF resume *and* a portfolio site — no more drift between them
+- 🖨️ **Auto-Rendered PDF Resume** - rendercv-powered, downloadable, regenerates on every push
+- 🎭 **Multi-Mode Portfolio** - splash page picks between retro terminal and editorial GUI; both render from the same data
+- 🚀 **Zero-Code Setup** - visual resume builder + AI converter, no programming needed
+- 📊 **`show_on_resume` Flag** - mark which projects/entries land in the PDF vs. site-only
+- 🤖 **AI Resume Converter** - paste an existing resume, get clean `resume.yaml`
+- 🎨 **Themes & Polish** - matrix/blue/purple/amber terminal themes; scroll-pinned animations + sparklines + PWA install in GUI mode
+- 📱 **Fully Responsive** - works on desktop, tablet, and mobile
+- 🔍 **Smart Search** - search across all your content instantly
+- 📂 **Custom Fields & Dynamic Sections** - add any field/section; appears in GUI and becomes a terminal command automatically
+- 🔒 **Secure & Accessible** - XSS protection, Content Security Policy, ARIA labels, keyboard nav
+- 🔄 **Auto-Deploy** - push to GitHub, site rebuilds automatically
 
 ## 🌟 Easy Mode - Get Started in 10 Minutes
 
@@ -220,7 +219,7 @@ Customize the PWA (installable app) settings:
 
    ```json
    {
-     "name": "Your Name - Terminal Portfolio",
+     "name": "Your Name - Portfolio",
      "short_name": "Your Portfolio",
      "description": "Your description here"
    }
@@ -293,7 +292,7 @@ languages:
 
 - ✅ **Custom Fields:** Add any extra fields to standard sections - they appear in your portfolio automatically
 - ✅ **Dynamic Sections:** Create new sections (like certifications, awards, languages) - they become terminal commands!
-- ✅ **Web Interface:** Custom fields and sections are fully accessible in your terminal portfolio
+- ✅ **Web Interface:** Custom fields and sections appear in both terminal and GUI modes
 - ✅ **PDF Generation:** Custom fields are automatically stripped for RenderCV compatibility
 - ✅ **Zero Errors:** No manual management needed - it just works!
 - ✅ **Fully Backward Compatible:** All existing resumes continue to work

--- a/client/src/components/gui/ReplicateSheet.tsx
+++ b/client/src/components/gui/ReplicateSheet.tsx
@@ -173,10 +173,11 @@ export default function ReplicateSheet({ active, onClose }: ReplicateSheetProps)
               Build your own
             </h2>
             <p className="text-zinc-400 text-xs sm:text-sm leading-relaxed mb-5 max-w-xl">
-              this site is a template — fork it, drop in a{' '}
-              <span className="text-white">resume.yaml</span>, and you have a
-              full portfolio deployed to GitHub Pages in under ten minutes:
-              splash → terminal mode → editorial GUI mode, one source of truth.
+              your resume and portfolio site, always in sync. one{' '}
+              <span className="text-white">resume.yaml</span> drives a PDF
+              resume + a multi-mode portfolio (splash → terminal → editorial
+              GUI). fork it, drop in your YAML, and deploy to GitHub Pages in
+              under ten minutes.
             </p>
 
             {/* Headline count + stats line */}

--- a/client/src/components/tui/ReplicatePage.tsx
+++ b/client/src/components/tui/ReplicatePage.tsx
@@ -15,8 +15,9 @@ export function ReplicatePage() {
         {/* Pitch — sets the payoff + time before any steps. Two ETAs
             because "have a resume?" vs "starting fresh?" diverge here. */}
         <div className="text-white/80 text-xs sm:text-sm mb-1">
-          fork this portfolio template. drop in a{' '}
-          <Code>resume.yaml</Code>, deploy. terminal + editorial GUI, one source.
+          your resume and portfolio site, always in sync. one{' '}
+          <Code>resume.yaml</Code> drives a PDF resume + a multi-mode portfolio
+          site (splash → terminal → editorial GUI). fork, drop in your YAML, deploy.
         </div>
         <div className="text-tui-muted text-xs mb-3">
           ~5 min if you have a resume · ~10 min from scratch
@@ -149,12 +150,12 @@ cp client/public/manifest.json.example client/public/manifest.json`}
         <PhaseHeader title="what you get" />
         <PhaseBody>
           <div className="text-xs sm:text-sm text-white/80 grid grid-cols-1 sm:grid-cols-2 gap-x-6 gap-y-1">
+            <Bullet>auto-rendered pdf resume</Bullet>
             <Bullet>live at <Code>&lt;your-username&gt;.github.io</Code></Bullet>
             <Bullet>pwa-installable (offline-ready)</Bullet>
-            <Bullet>auto-rendered pdf resume</Bullet>
+            <Bullet>themes + custom commands</Bullet>
             <Bullet>ascii name banner</Bullet>
             <Bullet>neofetch system info</Bullet>
-            <Bullet>themes + custom commands</Bullet>
           </div>
         </PhaseBody>
 

--- a/docs/ADVANCED.md
+++ b/docs/ADVANCED.md
@@ -1,6 +1,6 @@
 # Advanced Customization Guide
 
-This guide is for developers who want to customize the terminal portfolio beyond just updating the resume.
+This guide is for developers who want to customize the portfolio template beyond just updating the resume — terminal mode, GUI mode, splash page, and the build pipeline that emits both the PDF resume and the website JSON from `resume.yaml`.
 
 ## 🎯 Prerequisites
 
@@ -106,7 +106,7 @@ terminal:
 
 pwa:
   enabled: true
-  name: "Your Name - Terminal Portfolio"
+  name: "Your Name - Portfolio"
   shortcuts:
     - name: "About Me"
       command: "about"
@@ -318,7 +318,7 @@ const RENDERCV_ALLOWED_FIELDS = {
 
 ### Accessing Custom Fields in Code
 
-If you want to display custom fields in the terminal interface:
+If you want to display custom fields in terminal mode (GUI mode renders them automatically from the JSON):
 
 **In `client/src/hooks/useTerminal.ts`:**
 
@@ -679,7 +679,7 @@ Edit `client/public/manifest.json`:
 {
   "name": "Your Name - Developer Portfolio",
   "short_name": "Portfolio",
-  "description": "Interactive terminal portfolio showcasing my work",
+  "description": "Interactive portfolio showcasing my work",
   "start_url": "/",
   "display": "standalone",
   "background_color": "#000000",

--- a/docs/DEPLOYMENT.md
+++ b/docs/DEPLOYMENT.md
@@ -1,6 +1,6 @@
 # Deployment Guide
 
-This guide explains how your terminal portfolio is automatically deployed to GitHub Pages.
+This guide explains how your portfolio is automatically deployed to GitHub Pages. The deploy workflow runs `rendercv` on `resume.yaml` to emit both `resume.pdf` and `resume.json` — terminal mode and GUI mode then render from the same JSON, so a single push updates both surfaces in lockstep with the PDF.
 
 ## 🌟 Easy Mode (Zero-Code Deployment)
 

--- a/docs/TROUBLESHOOTING.md
+++ b/docs/TROUBLESHOOTING.md
@@ -1,6 +1,6 @@
 # Troubleshooting Guide
 
-Common issues and solutions for your terminal portfolio.
+Common issues and solutions for your portfolio.
 
 ## 🚫 Deployment Issues
 

--- a/docs/UPGRADING.md
+++ b/docs/UPGRADING.md
@@ -45,7 +45,7 @@ git merge upstream/main
 git push origin main
 ```
 
-If the merge is clean, GitHub Actions redeploys your site automatically.
+If the merge is clean, GitHub Actions redeploys your site automatically. After deploy, smoke-test both surfaces: open your site, exercise terminal mode (default load) and GUI mode (splash toggle or `/#gui`) — engine upgrades occasionally touch shared rendering paths, so a quick parity check catches regressions early.
 
 ### When merge conflicts happen
 

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "subhayu99.github.io",
   "version": "1.0.0",
-  "description": "Interactive portfolio template — terminal mode + editorial GUI mode from one resume.yaml, zero-code deployment to GitHub Pages",
+  "description": "One resume.yaml emits a PDF resume + a multi-mode portfolio site (splash → terminal → editorial GUI). Always in sync, zero-code GitHub Pages deploy.",
   "type": "module",
   "license": "MIT",
   "author": "Subhayu Kumar Bala <balasubhayu99@gmail.com>",

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -26,7 +26,7 @@ const siteMetadataPlugin = (): Plugin => {
     name: 'site-metadata-injector',
     transformIndexHtml(html) {
       let title = 'Portfolio';
-      let description = 'Interactive portfolio — terminal mode + editorial GUI mode';
+      let description = 'Resume + portfolio site, always in sync — one resume.yaml drives both';
 
       try {
         // Try to read from resume.json (generated from resume.yaml)


### PR DESCRIPTION
## Summary

Repositions the project's user-facing messaging from "Portfolio Template (terminal mode + GUI mode)" to **"single source of truth that ends resume↔website drift"** — the actual origin story. The terminal/GUI multi-mode is reframed as a feature of the output, not the lead.

The trigger: even after the earlier rename pass (`6010156`), the lead pitches across surfaces still sold the visual modes ("fork this portfolio template, terminal + editorial GUI, one source") instead of the workflow pain the project solves. This PR threads the drift-killer narrative through every user-facing surface.

## What changed

- **`README.md`** — replaces tagline blockquote with `### One YAML. Resume + portfolio. Always in sync.` + origin-story explainer; reorders Features list to lead with Single Source of Truth → Auto-Rendered PDF → Multi-Mode Portfolio (drops "Beautiful Terminal UI" as the first bullet); light terminology pass on body.
- **`client/src/components/tui/ReplicatePage.tsx`** — top blurb now leads with the resume-sync story; "auto-rendered pdf resume" promoted from the 3rd to 1st bullet in "what you get".
- **`client/src/components/gui/ReplicateSheet.tsx`** — pitch alignment, same framing.
- **`docs/*.md`** — terminology sweep (`terminal portfolio` → `portfolio` / mode-aware phrasing) across ADVANCED, DEPLOYMENT, TROUBLESHOOTING, UPGRADING. Light additions: smoke-test-both-modes callouts in MAINTAINER_GUIDE and UPGRADING; multi-mode goal added to CONTRIBUTING.
- **`package.json` description** + **`vite.config.ts` HTML meta description** — aligned with the hook so npm metadata + OG/Twitter share cards match.

## Out of scope (queued for follow-up branch)

- "How It Works" architecture section + Mermaid diagram in README
- "GUI Customization" section in `docs/ADVANCED.md`
- `FUTURE_ENHANCEMENTS.md` cleanup (move completed items out)
- Demo GIF refresh via Playwright

## `resume.yaml` follow-up (separate, on `personal`)

Proposed copy for the `personal_projects` "Portfolio Template" entry to weave in the sync narrative is in the docs-multimode branch chat history. Not in this PR's diff because `resume.yaml` is gitignored on `main`.

## Test plan

- [x] `npm run build` clean
- [x] `npm run type-check` produces same 20 pre-existing errors, none new
- [x] Canonical "always in sync" appears in 5 surfaces (README h3, ReplicatePage, ReplicateSheet, package.json, vite.config.ts)
- [x] Zero stale `terminal portfolio` / `Beautiful Terminal UI` outside literal commands
- [x] Live site smoke-test: open `/#terminal` and `/#gui`, hit replicate sheet, eyeball the new lead pitches