### PR TITLE
docs: How It Works diagram, GUI customization guide, FUTURE cleanup, refreshed demo GIF

### DIFF
--- a/FUTURE_ENHANCEMENTS.md
+++ b/FUTURE_ENHANCEMENTS.md
@@ -1,12 +1,16 @@
 # 🚀 Future Enhancements
 
-Ideas and improvements to implement in future versions.
+Living list of ideas for upcoming work. Items already shipped live in the **Archive** at the bottom — kept for design history, not as active work.
 
-## High Priority
+---
 
-### `cat resume.txt` is broken! Need to fix
+## ⭐ Active
 
-### Make Resume Sections Optional for Students
+### High Priority
+
+#### `cat resume.txt` is broken — needs fix
+
+#### Make Resume Sections Optional for Students
 **Issue**: Currently all sections (experience, projects) are required, which isn't ideal for students who may not have work experience yet.
 
 **Solution**: Make these sections optional in the schema:
@@ -31,178 +35,9 @@ Ideas and improvements to implement in future versions.
 - More inclusive for early-career developers
 - Cleaner resumes for career changers
 
----
+### Medium Priority
 
-### ✅ Fix Date Parsing Logic (COMPLETED)
-**Status**: Implemented with date-fns multi-format parser
-
-**Issue**: Current regex-based date parsing breaks on common formats, causing incorrect dates in timeline and displays.
-
-**Problems**:
-- `"May 2025"` → parses as `"January 2025"` (month information lost)
-- `"Oct 2023 — Dec 2023"` → fails to parse (em-dash not handled)
-- Date ranges with en-dash/em-dash (`–`, `—`) cause parsing failures
-- No validation or error messages for unparseable formats
-
-**Current Implementation** (`client/src/hooks/useTerminal.ts:23-39`):
-```typescript
-const parseDate = (dateStr: string): Date => {
-  const cleanDate = dateStr.replace(/[^\d-]/g, '').trim();
-  // This strips ALL non-digit chars, losing "May" in "May 2025"
-  if (cleanDate.includes('-')) {
-    const [year, month] = cleanDate.split('-');
-    return new Date(parseInt(year), month ? parseInt(month) - 1 : 0);
-  }
-  return new Date(parseInt(cleanDate), 0);
-};
-```
-
-**Solution**: Use `date-fns` library (already in package.json) to support multiple formats:
-- ISO formats: `"2023-03-28"`, `"2022-06"`, `"2021"`
-- Month-Year: `"May 2025"`, `"Jan 2024"`, `"Sep 2021"`
-- Date ranges: `"Jul 2025 – Present"`, `"Oct 2023 — Dec 2023"`
-- Add proper validation and error handling
-
-**Work Required**:
-1. Implement multi-format parser using `date-fns.parse()` with format detection
-2. Add date range parser to handle separators (`–`, `—`, `-`, `to`)
-3. Handle "Present" keyword for ongoing dates
-4. Add validation and fallback for unparseable dates
-5. Test against all date formats currently in `resume.yaml`
-
-**Estimated effort**: 5-7 hours
-
-**Benefits**:
-- Fixes timeline display bugs for projects and experience
-- Supports flexible date formats like RenderCV
-- Better error messages help users debug date issues
-- No new dependencies needed (date-fns already included)
-
-**Implementation** (`client/src/hooks/useTerminal.ts:23-72`):
-- Replaced regex-based parser with date-fns multi-format parser
-- Added support for ISO formats, Month-Year formats, and date ranges
-- Handles "Present" keyword for ongoing dates
-- Includes proper validation and fallback error handling
-- Supports en-dash (–), em-dash (—), hyphen (-), and "to" as range separators
-
----
-
-### ✅ Fix PDF Section Ordering (COMPLETED)
-**Status**: Implemented with sortKeys: false in YAML processing
-
-**Issue**: Reordering sections in `resume.yaml` doesn't change the section order in the generated PDF resume.
-
-**Current Behavior**:
-- Sections appear in a fixed order in PDF regardless of YAML order
-- Users cannot customize section ordering for their career stage
-- Students cannot prioritize education/projects over limited experience
-- Professionals cannot lead with experience over education
-
-**Root Cause** (Investigation needed):
-Likely causes in `scripts/generate-resume.js`:
-1. **js-yaml sortKeys**: `yaml.load()` might be using `sortKeys: true` (alphabetical sorting)
-2. **RenderCV Template**: The classic template might have hardcoded section order
-3. **Data Transformation**: The script might be reconstructing objects in fixed order when filtering projects
-
-**How RenderCV Should Handle This**:
-- Section order in YAML input should equal section order in PDF output
-- Python's dict preserves insertion order (Python 3.7+)
-- RenderCV uses `ruamel.yaml` which preserves YAML order
-
-**Solution**: Ensure order preservation throughout the pipeline
-
-**Work Required**:
-1. **Fix js-yaml loading** (scripts/generate-resume.js):
-   ```javascript
-   const fullData = yaml.load(yamlContent, {
-     sortKeys: false  // Preserve YAML order
-   });
-   ```
-
-2. **Investigate object reconstruction** (scripts/generate-resume.js:163-187):
-   - When filtering projects, ensure sections object is rebuilt in original order
-   - Use `Object.entries()` and reduce to maintain order
-   - Avoid object spread which might reorder keys
-
-3. **Verify RenderCV template**: Check if classic template respects input order
-   - May need to switch template or configure section order
-   - Check RenderCV documentation for section ordering options
-
-4. **Add validation**:
-   - Log section order before writing temp YAML
-   - Verify order preservation after each transformation
-
-5. **Add tests**:
-   - Create test resume with unusual order (education first, then experience)
-   - Verify PDF matches YAML order
-
-6. **Document the feature** once working:
-   - Add examples to README.md and docs/ADVANCED.md
-   - Show different orderings for students vs professionals
-
-**Estimated effort**: 4-6 hours (investigation + implementation + testing)
-
-**Benefits**:
-- Users can customize resume structure for their career stage
-- Students can prioritize education and projects over limited experience
-- Professionals can lead with experience and achievements
-- Better alignment with RenderCV's flexible philosophy
-
-**Implementation** (`scripts/generate-resume.js`):
-- Added `sortKeys: false` to yaml.load() (line 60) to preserve YAML key order
-- Added `sortKeys: false` to yaml.dump() (line 162) to maintain order when writing
-- Added verbose logging to display section order at load and before PDF generation
-- Sections now render in PDF in the exact order they appear in resume.yaml
-
-**Testing**: Verified by reordering sections in resume.yaml and generating PDF ✓
-
----
-
-## Medium Priority
-
-### ✅ Neofetch Auto-Fallback (COMPLETED)
-**Status**: Implemented in useTerminal.ts
-
-When neofetch.txt doesn't exist, the system now auto-generates a simple banner showing:
-- Name (centered, bold)
-- Contact info (email, phone, location, website)
-- Top 5 skills
-- Clean ASCII art borders
-- Helpful tip to create custom banner
-
-Users no longer need to manually create neofetch files.
-
----
-
-## Medium Priority
-
-### ✅ Resume to YAML Converter (COMPLETED)
-**Status**: Implemented with dynamic schema generation and modal UI
-
-**Implementation**:
-- Created scripts/generate-ai-prompt.js that dynamically parses shared/schema.ts
-- Generates comprehensive AI conversion prompt at build time
-- Modal UI in replicate command for easy access and clipboard copying
-- Prompt includes schema docs, formatting guidelines, and example
-- 15KB prompt file generated to client/public/data/ai-resume-prompt.txt
-
-**User workflow**:
-1. Type "replicate" command in terminal
-2. Click "Get AI Conversion Prompt" button
-3. Copy prompt from modal
-4. Paste into any AI tool (ChatGPT, Claude, Gemini) with resume
-5. Get valid resume.yaml output
-
-**Benefits achieved**:
-- Zero hardcoded schema - fully dynamic from TypeScript definitions
-- Always up-to-date with schema changes
-- Works with any AI tool (user's choice)
-- No API costs or rate limits
-- Significantly reduces setup time for new users
-
----
-
-### Fix TypeScript Strict Null-Checking Errors
+#### Fix TypeScript Strict Null-Checking Errors
 **Issue**: ~50 TypeScript errors in `client/src/hooks/useTerminal.ts` due to accessing optional schema fields without null checks.
 
 **Background**:
@@ -231,73 +66,165 @@ Users no longer need to manually create neofetch files.
 - Improved type safety
 - Professional code quality
 
+### Low Priority
+
+#### Voice Commands
+Enable voice input for terminal commands using Web Speech API.
+
+#### Custom Command Framework
+Allow users to define custom commands in config file.
+
+#### Multi-language Support
+Support for resume in multiple languages.
+
 ---
 
-### ✅ Make Schema More Flexible (COMPLETED - All Phases)
+## ✅ Archive — Shipped
 
-**Status**: Custom fields, optional fields, dynamic rendering, AND dynamic sections all implemented!
+These items are live in the codebase. Kept here for design rationale and history; not active work.
 
-**Issue**: Current schema is too rigid - doesn't allow custom sections or extra fields like RenderCV does.
+### Date Parsing Logic
+**Status**: Implemented with date-fns multi-format parser.
 
-**Previous Limitations** (ALL FIXED):
+**Issue**: Original regex-based date parsing broke on common formats, causing incorrect dates in timeline and displays.
 
-1. ~~**Fixed Section Names**: Only supports hardcoded sections~~ ✅ **FIXED**
-   - ~~Cannot add custom sections like "Certifications" or "Awards"~~ ✅ Now fully supported via `.catchall()`
-2. ~~**Strict Field Requirements**: Many fields are required even when not applicable~~ ✅ **FIXED**
-   - ~~Experience requires `location` (problematic for remote-first roles)~~ ✅ Now optional
-   - ~~Projects require `highlights` array (should be optional)~~ ✅ Now optional with default
-3. ~~**No Custom Fields**: Cannot add extra fields to entries~~ ✅ **FIXED**
-   - ~~Cannot add `company_logo_url` or `github_repo` to projects~~ ✅ Now supported via .passthrough()
-   - ~~Cannot add `relevance_score` or custom metadata~~ ✅ Now supported
+**Problems**:
+- `"May 2025"` → parsed as `"January 2025"` (month information lost)
+- `"Oct 2023 — Dec 2023"` → failed to parse (em-dash not handled)
+- Date ranges with en-dash/em-dash (`–`, `—`) caused parsing failures
+- No validation or error messages for unparseable formats
 
-**How RenderCV Handles This**:
+**Original Implementation** (`client/src/hooks/useTerminal.ts:23-39`):
+```typescript
+const parseDate = (dateStr: string): Date => {
+  const cleanDate = dateStr.replace(/[^\d-]/g, '').trim();
+  // This strips ALL non-digit chars, losing "May" in "May 2025"
+  if (cleanDate.includes('-')) {
+    const [year, month] = cleanDate.split('-');
+    return new Date(parseInt(year), month ? parseInt(month) - 1 : 0);
+  }
+  return new Date(parseInt(cleanDate), 0);
+};
+```
 
-- **Flexible Sections**: "Section titles are arbitrary" - use any section names
-- **Minimal Requirements**: Only truly essential fields are required ✅ **Implemented**
-- **Extra Fields Supported**: "RenderCV allows the usage of any number of extra keys in the entries" ✅ **Implemented**
-- **Graceful Handling**: Custom fields don't break output, can be used in custom designs ✅ **Implemented**
+**Solution**: Use `date-fns` library (already in package.json) to support multiple formats:
+- ISO formats: `"2023-03-28"`, `"2022-06"`, `"2021"`
+- Month-Year: `"May 2025"`, `"Jan 2024"`, `"Sep 2021"`
+- Date ranges: `"Jul 2025 – Present"`, `"Oct 2023 — Dec 2023"`
+
+**Implementation** (`client/src/hooks/useTerminal.ts:23-72`):
+- Replaced regex-based parser with date-fns multi-format parser
+- Added support for ISO formats, Month-Year formats, and date ranges
+- Handles "Present" keyword for ongoing dates
+- Includes proper validation and fallback error handling
+- Supports en-dash (–), em-dash (—), hyphen (-), and "to" as range separators
+
+### PDF Section Ordering
+**Status**: Implemented with `sortKeys: false` in YAML processing.
+
+**Issue**: Reordering sections in `resume.yaml` didn't change the section order in the generated PDF resume.
+
+**Original Behavior**:
+- Sections appeared in a fixed order in PDF regardless of YAML order
+- Users couldn't customize section ordering for their career stage
+- Students couldn't prioritize education/projects over limited experience
+- Professionals couldn't lead with experience over education
+
+**Solution**: Ensure order preservation throughout the pipeline.
+
+**Implementation** (`scripts/generate-resume.js`):
+- Added `sortKeys: false` to `yaml.load()` (line 60) to preserve YAML key order
+- Added `sortKeys: false` to `yaml.dump()` (line 162) to maintain order when writing
+- Added verbose logging to display section order at load and before PDF generation
+- Sections now render in PDF in the exact order they appear in `resume.yaml`
+
+**Testing**: Verified by reordering sections in `resume.yaml` and generating PDF ✓
+
+### Neofetch Auto-Fallback
+**Status**: Implemented in `useTerminal.ts`.
+
+When `neofetch.txt` doesn't exist, the system now auto-generates a simple banner showing:
+- Name (centered, bold)
+- Contact info (email, phone, location, website)
+- Top 5 skills
+- Clean ASCII art borders
+- Helpful tip to create custom banner
+
+Users no longer need to manually create neofetch files.
+
+### Resume to YAML Converter
+**Status**: Implemented with dynamic schema generation and modal UI.
+
+**Implementation**:
+- Created `scripts/generate-ai-prompt.js` that dynamically parses `shared/schema.ts`
+- Generates comprehensive AI conversion prompt at build time
+- Modal UI in `replicate` command for easy access and clipboard copying
+- Prompt includes schema docs, formatting guidelines, and example
+- 15KB prompt file generated to `client/public/data/ai-resume-prompt.txt`
+
+**User workflow**:
+1. Type `replicate` command in terminal
+2. Click "Get AI Conversion Prompt" button
+3. Copy prompt from modal
+4. Paste into any AI tool (ChatGPT, Claude, Gemini) with resume
+5. Get valid `resume.yaml` output
+
+**Benefits achieved**:
+- Zero hardcoded schema — fully dynamic from TypeScript definitions
+- Always up-to-date with schema changes
+- Works with any AI tool (user's choice)
+- No API costs or rate limits
+- Significantly reduces setup time for new users
+
+### Schema Flexibility (custom fields, optional fields, dynamic sections)
+**Status**: Custom fields, optional fields, dynamic rendering, AND dynamic sections all implemented.
+
+**Issue**: Original schema was too rigid — didn't allow custom sections or extra fields like RenderCV does.
+
+**Previous Limitations** (all fixed):
+
+1. **Fixed Section Names**: Only supported hardcoded sections → ✅ Now supports arbitrary sections via `.catchall()`
+2. **Strict Field Requirements**: Many fields were required even when not applicable → ✅ Now optional (e.g. `location` for remote roles, `highlights` arrays)
+3. **No Custom Fields**: Couldn't add extra fields to entries → ✅ Now supported via `.passthrough()` (e.g. `company_logo_url`, `github_repo`, `relevance_score`)
+
+**How RenderCV Handles This** (now mirrored):
+- **Flexible Sections**: section titles are arbitrary
+- **Minimal Requirements**: only truly essential fields are required
+- **Extra Fields Supported**: any number of extra keys allowed in entries
+- **Graceful Handling**: custom fields don't break output
 
 **Implementation** (`shared/schema.ts`):
 
-**Phase 1: Custom Fields Support** ✅ **COMPLETED**
-
+**Phase 1: Custom Fields Support**
 - Added `.passthrough()` to all 6 schemas:
-  - `socialNetworkSchema` - allows custom fields like `profile_url`, `verified`
-  - `technologySchema` - allows custom fields like `proficiency_level`, `years_experience`
-  - `experienceSchema` - allows custom fields like `github_team`, `tech_stack`, `team_size`
-  - `educationSchema` - allows custom fields like `gpa`, `honors`, `thesis_title`
-  - `projectSchema` - allows custom fields like `github_repo`, `live_url`, `tech_stack`
-  - `publicationSchema` - allows custom fields like `citation_count`, `impact_factor`
+  - `socialNetworkSchema` — custom fields like `profile_url`, `verified`
+  - `technologySchema` — custom fields like `proficiency_level`, `years_experience`
+  - `experienceSchema` — custom fields like `github_team`, `tech_stack`, `team_size`
+  - `educationSchema` — custom fields like `gpa`, `honors`, `thesis_title`
+  - `projectSchema` — custom fields like `github_repo`, `live_url`, `tech_stack`
+  - `publicationSchema` — custom fields like `citation_count`, `impact_factor`
 
-**Phase 2: Optional Fields** ✅ **COMPLETED**
-
+**Phase 2: Optional Fields**
 - Made `location` optional in `experienceSchema` (supports remote/distributed roles)
-- Made `highlights` optional with `default([])` in:
-  - `experienceSchema` - simple roles don't need highlights
-  - `projectSchema` - not all projects need detailed highlights
-- Made `location` optional in `educationSchema` (was already done)
-- Made `highlights` optional in `educationSchema`
+- Made `highlights` optional with `default([])` in `experienceSchema` and `projectSchema`
+- Made `location` and `highlights` optional in `educationSchema`
 
-**Phase 2.5: Dynamic Custom Field Rendering** ✅ **COMPLETED**
-
+**Phase 2.5: Dynamic Custom Field Rendering**
 - Created `client/src/lib/fieldRenderer.ts` utility for automatic custom field detection and display
 - Integrated into terminal display functions: `showExperience`, `showEducation`, `showProjects`
 - Type-aware rendering:
-  - **URLs**: Become clickable links with hover effects
-  - **Booleans**: Show ✓ Yes / ✗ No indicators
-  - **Arrays**: Display as formatted chip badges
-  - **Numbers**: Highlighted in bold
-  - **Strings**: Sanitized for XSS protection
-  - **Objects**: Simplified representation
+  - **URLs**: clickable links with hover effects
+  - **Booleans**: ✓ Yes / ✗ No indicators
+  - **Arrays**: formatted chip badges
+  - **Numbers**: highlighted in bold
+  - **Strings**: sanitized for XSS protection
+  - **Objects**: simplified representation
 - Field name formatting: `tech_stack` → "Tech Stack" (snake_case to Title Case)
 - Custom fields display in "📋 Additional Info" section below core content
 - Automatically excludes core fields (company, position, highlights, etc.)
-- Zero hardcoding required - any new custom field automatically renders
 
-**Phase 3: Dynamic Section Names** ✅ **COMPLETED**
-
+**Phase 3: Dynamic Section Names**
 ```typescript
-// Implemented! Now supports arbitrary section names
 sections: z.object({
   // Standard sections for backward compatibility
   intro: z.array(z.string()).optional(),
@@ -307,48 +234,21 @@ sections: z.object({
   professional_projects: z.array(projectSchema).optional(),
   personal_projects: z.array(projectSchema).optional(),
   publication: z.array(publicationSchema).optional(),
-}).catchall(z.array(sectionEntrySchema)), // ✨ Allow any section names!
+}).catchall(z.array(sectionEntrySchema)), // Allow any section names
 ```
 
-**Implementation** (`shared/schema.ts:50-80`):
-- Created `sectionEntrySchema` union type covering all RenderCV entry types
-- Used `.catchall()` to validate arbitrary section arrays
-- Maintains backward compatibility with standard sections
-
-**Implementation** (`scripts/generate-resume.js:105-169`):
-- Added `detectEntryType()` function for dynamic type detection
-- Added `getAllowedFieldsForEntryType()` for RenderCV compatibility
-- Updated `stripCustomFields()` to handle dynamic sections
-- Unknown sections with unknown entry types preserved as-is (safety fallback)
-
-**Implementation** (`client/src/hooks/useTerminal.ts:961-1092`):
-- Created `showGenericSection()` renderer for dynamic sections
-- Automatically detects entry type and renders appropriately
-- Supports all RenderCV entry types: Experience, Education, NormalEntry, OneLineEntry, PublicationEntry, TextEntry
-- Integrated custom field rendering for all entry types
-
-**Command System** (`client/src/hooks/useTerminal.ts:401-433`):
-- Updated `getAvailableCommands()` to dynamically register custom sections
-- Custom sections automatically appear in `help` command
-- Commands like `certifications`, `awards`, etc. work out-of-the-box
-- Default case in executeCommand checks for dynamic sections
-
-**Actual effort**: ~4 hours (as estimated!)
+**Implementation across files**:
+- `shared/schema.ts:50-80` — `sectionEntrySchema` union type covering all RenderCV entry types; `.catchall()` to validate arbitrary section arrays
+- `scripts/generate-resume.js:105-169` — `detectEntryType()` for dynamic type detection; `getAllowedFieldsForEntryType()` for RenderCV compatibility; updated `stripCustomFields()` to handle dynamic sections
+- `client/src/hooks/useTerminal.ts:961-1092` — `showGenericSection()` renderer for dynamic sections; auto-detects entry type; supports all RenderCV entry types (Experience, Education, NormalEntry, OneLineEntry, PublicationEntry, TextEntry)
+- `client/src/hooks/useTerminal.ts:401-433` — `getAvailableCommands()` dynamically registers custom sections; commands like `certifications`, `awards`, etc. work out-of-the-box
 
 **Documentation**:
-
 - Updated `resume.yaml.example` with custom field examples and comments
-- All schemas now include inline comments explaining the flexibility
-- Updated `scripts/generate-resume.js` with complete RenderCV field mappings:
-  - All documented RenderCV fields now supported (summary, date, etc.)
-  - Linked to official RenderCV documentation with maintenance reminder
-  - Preserves design, locale, and rendercv_settings fields
-- Created `client/src/lib/fieldRenderer.ts` for dynamic custom field rendering
-- Updated `client/src/hooks/useTerminal.ts` to display custom fields automatically in terminal
+- All schemas include inline comments explaining the flexibility
+- Updated `scripts/generate-resume.js` with complete RenderCV field mappings; linked to official RenderCV documentation
 
 **How Custom Fields Work**:
-
-Custom fields are fully supported with automatic compatibility handling:
 
 1. **Web Interface**: Custom fields are preserved in `resume.json` and surface in both terminal and GUI modes
 2. **Terminal Display**: Custom fields automatically render in terminal mode via dynamic field renderer
@@ -356,30 +256,7 @@ Custom fields are fully supported with automatic compatibility handling:
 4. **Schema Validation**: Zod schemas use `.passthrough()` to accept any extra fields
 5. **Backward Compatibility**: RenderCV's strict Pydantic schema doesn't break the build
 
-This "best of both worlds" approach means:
-
-- Users can add custom fields for the web interface (e.g., `profile_url`, `tech_stack`, `gpa`)
-- PDF generation always works (unknown fields auto-stripped)
-- No manual field management required
-
-**Benefits Achieved**:
-
-- ✅ Users can add custom fields to any entry (profile_url, tech_stack, gpa, etc.)
-- ✅ Custom fields automatically display in terminal mode (no hardcoding needed); GUI mode reads them from the same JSON
-- ✅ Type-aware rendering makes data more readable and interactive
-- ✅ Support for non-traditional career paths (remote workers, freelancers)
-- ✅ Better alignment with RenderCV's philosophy of minimal requirements
-- ✅ Future-proof for new field requirements
-- ✅ More inclusive for diverse backgrounds
-- ✅ **Custom sections fully supported** (certifications, awards, volunteer_work, etc.)
-- ✅ **Dynamic command registration** - sections become terminal commands automatically
-- ✅ **Zero configuration** - add any section, it just works!
-
-**Breaking Changes**: None
-
-- Existing resume.yaml files continue to work unchanged
-- New features are opt-in via custom fields
-- Backward compatible with all existing resumes
+**Breaking Changes**: None. Existing `resume.yaml` files continue to work unchanged.
 
 **Example Use Cases** (now supported):
 
@@ -387,22 +264,22 @@ This "best of both worlds" approach means:
 social_networks:
   - network: "LinkedIn"
     username: "jane-developer"
-    profile_url: "https://linkedin.com/in/jane-developer"  # Custom field!
-    verified: true  # Custom field!
+    profile_url: "https://linkedin.com/in/jane-developer"  # Custom field
+    verified: true  # Custom field
 
 technologies:
   - label: "Languages"
     details: "JavaScript, TypeScript, Python"
-    proficiency_level: "Expert"  # Custom field!
-    years_experience: 5  # Custom field!
+    proficiency_level: "Expert"  # Custom field
+    years_experience: 5  # Custom field
 
 experience:
   - company: "Acme Corp"
     position: "Senior Engineer"
     # location is now optional - omit for fully remote roles
-    github_team: "acme-corp/platform"  # Custom field!
-    tech_stack: ["TypeScript", "React", "Node.js"]  # Custom field!
-    team_size: 8  # Custom field!
+    github_team: "acme-corp/platform"  # Custom field
+    tech_stack: ["TypeScript", "React", "Node.js"]  # Custom field
+    team_size: 8  # Custom field
     highlights: []  # Can be empty or omitted entirely
 
 education:
@@ -411,25 +288,24 @@ education:
     degree: "B.S."
     start_date: "2014"
     end_date: "2018"
-    gpa: 3.8  # Custom field!
-    honors: "Magna Cum Laude"  # Custom field!
-    # highlights is optional
+    gpa: 3.8  # Custom field
+    honors: "Magna Cum Laude"  # Custom field
 
-# ✨ NEW: Dynamic sections! Add ANY section you need:
+# Dynamic sections — add ANY section you need:
 certifications:
   - name: "AWS Certified Solutions Architect"
     date: "2024-03"
     highlights:
       - "Demonstrated expertise in designing distributed systems"
-    issuer: "Amazon Web Services"  # Custom field!
-    certification_id: "AWS-PSA-12345"  # Custom field!
+    issuer: "Amazon Web Services"  # Custom field
+    certification_id: "AWS-PSA-12345"  # Custom field
 
 awards:
   - name: "Engineering Excellence Award"
     date: "2024-01"
     highlights:
       - "Recognized for outstanding technical contribution"
-    awarded_by: "Tech Corp"  # Custom field!
+    awarded_by: "Tech Corp"  # Custom field
 
 languages:  # Simple text entries
   - "English (Native)"
@@ -442,20 +318,4 @@ interests:  # OneLineEntry format
 
 ---
 
-## Low Priority
-
-### Voice Commands
-
-Enable voice input for terminal commands using Web Speech API
-
-### Custom Command Framework
-
-Allow users to define custom commands in config file
-
-### Multi-language Support
-
-Support for resume in multiple languages
-
----
-
-**Note**: Keep this file updated as new ideas emerge!
+**Note**: Keep this file updated as new ideas emerge. Move shipped items to the Archive section so the Active list stays focused on what's actually next.

--- a/README.md
+++ b/README.md
@@ -44,6 +44,22 @@ This repository uses a **dual-branch strategy**:
 - 🔒 **Secure & Accessible** - XSS protection, Content Security Policy, ARIA labels, keyboard nav
 - 🔄 **Auto-Deploy** - push to GitHub, site rebuilds automatically
 
+## 🔧 How It Works
+
+```mermaid
+flowchart LR
+    yaml["📝 resume.yaml<br/><i>single source of truth</i>"]
+
+    yaml -->|rendercv| pdf["📄 resume.pdf<br/><i>downloadable</i>"]
+    yaml -->|build| json["📦 resume.json<br/><i>website data</i>"]
+
+    json --> splash["🎬 splash page"]
+    splash --> terminal["💻 terminal mode<br/><i>retro CRT</i>"]
+    splash --> gui["✨ editorial GUI<br/><i>scroll-pinned</i>"]
+```
+
+The build pipeline turns one YAML into both a PDF resume and a multi-mode website. `rendercv` produces the PDF; the same data flows into `resume.json`, which the splash page reads. Visitors pick **terminal mode** (retro CRT with commands, themes, hidden games) or **editorial GUI mode** (scroll-pinned animations, sparklines, PWA install). Both modes render from the same JSON, so they never drift from the PDF — that's the "always in sync" guarantee.
+
 ## 🌟 Easy Mode - Get Started in 10 Minutes
 
 Perfect for non-technical users! No installation of npm, Python, or any tools required.

--- a/docs/ADVANCED.md
+++ b/docs/ADVANCED.md
@@ -611,6 +611,85 @@ export const uiText = {
 };
 ```
 
+## ✨ GUI Mode Customization
+
+GUI mode (the editorial/scroll view) shares the same data and accent-color theming as terminal mode but has its own typography, animations, and section layouts. Most customization happens in code — there is no single config file that controls everything — but the entry points are documented here so you know where to look.
+
+### Accent Color (shared with terminal)
+
+The accent color is **single source of truth** for both modes. Themes are defined in `client/src/config/gui-theme.config.ts`:
+
+```typescript
+export const colorThemes: ColorTheme[] = [
+  { key: 'matrix',  name: 'Matrix Green',     accentRgb: [0, 255, 0],     accentHoverRgb: [0, 200, 0] },
+  { key: 'amber',   name: 'Vintage Amber',    accentRgb: [255, 120, 0],   accentHoverRgb: [210, 95, 0] },
+  // ...add your own theme here
+];
+```
+
+Calling `applyColorTheme(theme)` (already wired up via the `theme` terminal command) propagates the RGB tuple into all of these CSS variables in `client/src/index.css`:
+
+```
+--gui-accent          /* the bright accent (CTAs, headings, dots) */
+--gui-accent-hover    /* slightly darker variant for hover states */
+--gui-accent-rgb      /* "r, g, b" for use in rgba() */
+--gui-accent-ch       /* HSL channel for terminal scanline glow */
+```
+
+Plus the terminal HSL variables (`--terminal-bright-green` etc.). To add a custom theme, append a new entry to `colorThemes` — that's it; no other code changes required.
+
+### Splash Page
+
+The splash page shows on first visit (per browser session) and lets the visitor pick TERMINAL or GUI. Behavior lives in `client/src/hooks/useViewMode.ts`:
+
+- **Disable splash entirely / change default mode:** edit `getInitialViewMode()` to return `'gui'` or `'terminal'` instead of `'splash'`.
+- **Auto-advance timing:** `client/src/components/SplashPage.tsx` defines `IDLE_MS` (default `6000`). After that many ms of inactivity, the splash auto-progresses to GUI.
+- **Tagline:** auto-derived from your CV data via `deriveTagline()` in `SplashPage.tsx` (e.g. `"Data Engineer | 4 Years | 43k+ PyPI Downloads"`). Numbers come from PyPI stats + experience date math; no hardcoded text to edit.
+
+URL hashes bypass the splash on direct load: linking someone to `https://your-site.github.io/#gui` mounts GUI mode immediately.
+
+### Section Visibility
+
+GUI sections **auto-hide when their data is empty** — no flag needed. Each section component returns `null` if its data array is missing or empty, e.g. in `client/src/components/gui/ExperienceSection.tsx`:
+
+```typescript
+if (!experience?.length) return null;
+```
+
+So if your `resume.yaml` has no `publications`, the GUI Publications section silently disappears. Note that **`show_on_resume: false`** only excludes an entry from the **PDF** — GUI mode still renders it.
+
+### Animations
+
+Framer Motion configs are hardcoded inline in components (no central config). The most useful single file is `client/src/components/gui/SectionWrapper.tsx`, which defines the six entrance variants used across all sections:
+
+```typescript
+'fade-up': {
+  initial: { opacity: 0, y: 60, filter: 'blur(4px)' },
+  animate: { opacity: 1, y: 0, filter: 'blur(0px)' },
+  transition: { duration: 0.8, ease: [0.25, 0.1, 0.25, 1] },
+},
+// also: 'fade-left', 'fade-right', 'scale-up', 'split-open', 'blur-rise'
+```
+
+To slow everything down, bump the `duration` values; to disable entrance animations entirely, pass `variant="none"` from the consuming sections.
+
+### Hero Typography & Stats
+
+The hero's massive name typography (`text-7xl` / `text-[12rem]` responsive) lives in `client/src/components/gui/HeroSection.tsx` — Tailwind utility classes, not configurable via YAML. The font stack itself is set in `client/src/index.css` via the `font-display` class.
+
+Hero stat boxes (Years / Clients / Downloads / Packages) are derived automatically by `deriveStats()` in `HeroSection.tsx`. The function picks the top 4 stats by priority from your CV data (experience years, professional project count, PyPI downloads, etc.). To force a specific stat or hide one, edit the priority list directly in that function.
+
+### Summary
+
+| What you want to change | Where to edit |
+|---|---|
+| Add a custom accent color | `client/src/config/gui-theme.config.ts` |
+| Default to GUI/terminal (skip splash) | `client/src/hooks/useViewMode.ts` |
+| Splash auto-advance timing | `client/src/components/SplashPage.tsx` (`IDLE_MS`) |
+| Animation timing/easing | `client/src/components/gui/SectionWrapper.tsx` |
+| Hero stat selection | `client/src/components/gui/HeroSection.tsx` (`deriveStats`) |
+| Hide a GUI-only section | Just remove the data from `resume.yaml` |
+
 ## 🌐 API Integrations
 
 ### GitHub Stats (Live Repo Data)


### PR DESCRIPTION
## Summary

Follow-up polish to the docs-multimode rebrand (PR #24). Four focused commits, one PR.

## Changes

### 1. README — How It Works section with Mermaid diagram (`da8421c`)
Adds an architecture reveal between Features and Easy Mode:

\`\`\`mermaid
flowchart LR
    yaml --> pdf & json
    json --> splash --> terminal & gui
\`\`\`

Plus 80 words of prose explaining the unified pipeline — turns the "always in sync" claim from a hook into something readers can actually visualize.

### 2. `docs/ADVANCED.md` — GUI Mode Customization section (`64f117f`)
Mirrors the existing Terminal customization sections. Documents what's actually customizable, grounded in code:

- Accent color theming via `gui-theme.config.ts` (single source of truth for both modes — 9 prebuilt themes, RGB-tuple extensible)
- Splash page tweaks (disable, change default mode, idle timing — all in `useViewMode.ts` + `SplashPage.tsx`)
- Section auto-hide on empty data (and a clarification: `show_on_resume` only affects the PDF, not GUI)
- Animation pointers (Framer Motion configs are inline; `SectionWrapper.tsx` is the single most useful edit point)
- Hero typography + stat-derivation formula (`HeroSection.tsx::deriveStats()`)
- Summary table at the end mapping "what to change → where to edit"

+79 lines.

### 3. `FUTURE_ENHANCEMENTS.md` — Active + Archive split (`0518741`)
Reorganized so the Active list isn't buried under hundreds of lines of completed work:

- **⭐ Active** — High / Medium / Low priority items still pending
- **✅ Archive — Shipped** — completed items kept for design rationale

Content preserved (no deletion); 461 → 321 lines (trim from removed redundant `**Status**: Implemented...` headers and slight prose tightening — implementation details + code excerpts intact).

### 4. README — refreshed demo GIF (`5168544`)
Captured fresh via Playwright (headless Chromium, 1280×720), encoded with ffmpeg at 1024×576 / 12 fps. ~16s loop walks the canonical user flow:

- Splash page name scramble + TUI/GUI toggle
- TUI click → terminal mode with neofetch + identity card + quick tiles
- Hash navigation to GUI → editorial hero with name typography + stat counters
- Smooth scroll through experience → projects → education → publications → contact

Final size 6.4 MB (down from 6.5 MB baseline).

## Test plan

- [x] Mermaid diagram renders on GitHub
- [x] All "How It Works" prose claims match what `scripts/build.js` actually does
- [x] GUI customization claims grounded in code (Explore agent verified each file:line citation)
- [x] FUTURE_ENHANCEMENTS reorg preserves all content (diff shows only structural moves)
- [x] Demo GIF plays cleanly, all transitions visible at 12 fps
- [x] `npm run build` works (untested in this branch — no build-affecting changes)

## Out of scope

This PR does NOT touch `resume.yaml` or anything on the `personal` branch. PR #26 handles the resume entry update separately.