### PR TITLE
fix(resume): escape < to fix rendercv 'unclosed label' error

### DIFF
--- a/resume.yaml
+++ b/resume.yaml
@@ -195,7 +195,7 @@ cv:
         show_on_resume: true
         highlights:
           - "Open-sourced **this very portfolio** to fix resume↔website drift — `resume.yaml` is the single source: one file → PDF resume + multi-mode portfolio site (splash · terminal · GUI), always in sync."
-          - "Zero-code: fork, drop in YAML, deploy to GitHub Pages in <10 min — themes, AI converter, hidden games, scroll animations, sparklines, PWA install all included."
+          - "Zero-code: fork, drop in YAML, deploy to GitHub Pages in \\<10 min — themes, AI converter, hidden games, scroll animations, sparklines, PWA install all included."
           - "Click the title for live adoption stats; full source on [GitHub](https://github.com/subhayu99/subhayu99.github.io)."
         github_repo: "https://github.com/subhayu99/subhayu99.github.io"
         live_url: "#fork"


### PR DESCRIPTION
## Summary

PR #26 introduced an unescaped \`<\` in a resume bullet (\`"deploy to GitHub Pages in <10 min"\`), which Typst (rendercv's renderer) interprets as the start of a \`<label>\` token. The build that ran after merge failed with **"unclosed label"** at the rendercv step → no PDF regeneration → site is currently deployed without the freshly-rendered PDF.

## Fix

One-line YAML escape, matching the pattern already used elsewhere in the resume (\`\\<0.22%\`, \`\\<5s\`, \`\\>95%\`, \`\\>99.9%\`):

\`\`\`diff
- - "Zero-code: fork, drop in YAML, deploy to GitHub Pages in <10 min — ..."
+ - "Zero-code: fork, drop in YAML, deploy to GitHub Pages in \\<10 min — ..."
\`\`\`

YAML double-quoted \`\\\\<\` → parses as \`\\<\` → Typst treats as literal \`<\`.

## Reproduction + verification

Locally with rendercv **v2.3** (matching CI):

\`\`\`
Before fix:
  An error occurred: unclosed label
  ❌ Error running rendercv

After fix:
  ✅ rendercv completed successfully
  ✅ Copied Subhayu_Kumar_Bala_CV.pdf → client/public/resume.pdf
\`\`\`

## Failed run for reference

https://github.com/subhayu99/subhayu99.github.io/actions/runs/24991878686/job/73179185700

## Why this slipped past CI on PR #26

PR #26 was just a YAML content change with no CI-level rendercv step on personal-branch PRs (the deploy workflow only fires on merge-to-personal, not on PR opens). A one-time \`npm run generate-resume:prod\` smoke before merging would have caught it. Worth considering as a follow-up: add a render-pdf check on PRs that touch \`resume.yaml\` so this can't happen again.