### PR TITLE
feat(build): cache GitHub + PyPI API fetches via deployed-site cache

### DIFF
--- a/.github/workflows/deploy.yaml
+++ b/.github/workflows/deploy.yaml
@@ -27,6 +27,12 @@ on:
   pull_request:
     branches: [ main, personal ]
   workflow_dispatch:
+    inputs:
+      force_refresh:
+        description: 'Bypass build-time API caches (PyPI + GitHub stats). Used by the daily/weekly refresh workflows.'
+        type: boolean
+        required: false
+        default: false
 
 permissions:
   contents: read
@@ -127,6 +133,10 @@ jobs:
         # works) and /traffic/* (owner-only, will gracefully no-op if the
         # workflow's GITHUB_TOKEN lacks `administration: read`).
         GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        # Set to 1 by the daily/weekly refresh workflows to bypass the
+        # cache helpers. On normal pushes this stays unset, so each deploy
+        # reuses fresh JSON from the previous run / the live site.
+        FORCE_REFRESH: ${{ github.event.inputs.force_refresh == 'true' && '1' || '' }}
 
 
     - name: ⚙️  Configure GitHub Pages

--- a/.github/workflows/refresh-pypi-stats.yaml
+++ b/.github/workflows/refresh-pypi-stats.yaml
@@ -27,5 +27,11 @@ jobs:
             repo: context.repo.repo,
             workflow_id: 'deploy.yaml',
             ref: 'personal',
+            inputs: {
+              // Force-refresh the PyPI cache; otherwise the deploy would
+              // hit the cache helper and skip the actual fetch this cron
+              // exists to perform.
+              force_refresh: 'true',
+            },
           });
-          console.log('Triggered deploy workflow on personal branch');
+          console.log('Triggered deploy workflow on personal branch (force_refresh=true)');

--- a/.github/workflows/refresh-stats.yaml
+++ b/.github/workflows/refresh-stats.yaml
@@ -30,5 +30,11 @@ jobs:
             repo: context.repo.repo,
             workflow_id: 'deploy.yaml',
             ref: 'personal',
+            inputs: {
+              // Force-refresh the GitHub stats cache; otherwise the deploy
+              // would hit the cache helper and skip the actual fetch this
+              // cron exists to perform.
+              force_refresh: 'true',
+            },
           });
-          console.log('Triggered deploy workflow on personal branch');
+          console.log('Triggered deploy workflow on personal branch (force_refresh=true)');

--- a/scripts/fetch-pypi-stats.js
+++ b/scripts/fetch-pypi-stats.js
@@ -6,12 +6,17 @@
  * - pypistats.org: 180-day time series for sparkline charts (free API)
  *
  * Writes result to client/public/data/pypi-stats.json.
+ *
+ * Skips the remote fetch if a recent JSON exists locally OR on the deployed
+ * site (within CACHE_MAX_AGE_MS). Set FORCE_REFRESH=1 to bypass the cache.
  */
 
 import fs from 'fs';
 import path from 'path';
 import yaml from 'js-yaml';
 import { fileURLToPath } from 'url';
+import { tryLoadCache, isForceRefresh } from './utils/cache-helper.js';
+import { detectBaseUrl } from './utils/detect-repo.js';
 
 const __dirname = path.dirname(fileURLToPath(import.meta.url));
 const ROOT = path.resolve(__dirname, '..');
@@ -19,6 +24,9 @@ const PYPISTATS_BASE = 'https://pypistats.org/api/packages';
 const PEPY_BASE = 'https://pepy.tech/projects';
 const DELAY_MS = 3000; // Base delay between requests
 const MAX_RETRIES = 3;
+
+// Cache window: PyPI download counts move slowly (daily granularity is plenty).
+const CACHE_MAX_AGE_MS = 12 * 60 * 60 * 1000; // 12 hours
 
 function sleep(ms) {
   return new Promise(r => setTimeout(r, ms));
@@ -83,6 +91,28 @@ async function main() {
   if (!fs.existsSync(yamlPath)) {
     console.warn('[pypi-stats] resume.yaml not found, skipping');
     return;
+  }
+
+  const outPath = path.join(ROOT, 'client', 'public', 'data', 'pypi-stats.json');
+
+  // Cache check — skip remote fetch entirely if recent data is available
+  // either locally on this runner or on the deployed site itself.
+  const baseUrl = detectBaseUrl();
+  const cached = await tryLoadCache({
+    localPath: outPath,
+    remoteUrl: baseUrl ? `${baseUrl}/data/pypi-stats.json` : undefined,
+    freshnessKey: 'fetched_at',
+    maxAgeMs: CACHE_MAX_AGE_MS,
+  });
+  if (cached) {
+    console.log(
+      `[pypi-stats] ✓ using cached data (${cached.ageHours}h old, source=${cached.source}); skipping remote fetch`,
+    );
+    console.log(`[pypi-stats] (set FORCE_REFRESH=1 to override)`);
+    return;
+  }
+  if (isForceRefresh()) {
+    console.log('[pypi-stats] FORCE_REFRESH=1 — bypassing cache');
   }
 
   const doc = yaml.load(fs.readFileSync(yamlPath, 'utf8'));
@@ -172,7 +202,6 @@ async function main() {
     packages: stats,
   };
 
-  const outPath = path.join(ROOT, 'client', 'public', 'data', 'pypi-stats.json');
   fs.mkdirSync(path.dirname(outPath), { recursive: true });
   fs.writeFileSync(outPath, JSON.stringify(output, null, 2));
   console.log(`[pypi-stats] Wrote ${outPath}`);

--- a/scripts/fetch-stats.js
+++ b/scripts/fetch-stats.js
@@ -15,6 +15,11 @@
  *
  * Owner-scoped endpoints (traffic/clones, traffic/views) silently skip
  * when the token lacks `repo` scope or the script runs unauthenticated.
+ *
+ * Skips the remote fetch if a recent JSON exists locally OR on the deployed
+ * site (within CACHE_MAX_AGE_MS). Set FORCE_REFRESH=1 to bypass the cache.
+ * The /search/code orphan queries are the 429 hotspot — caching this file
+ * is the primary lever for staying under GitHub's secondary rate limits.
  */
 
 import { writeFileSync, mkdirSync } from 'fs';
@@ -22,6 +27,13 @@ import { join, dirname } from 'path';
 import { fileURLToPath } from 'url';
 import { execSync } from 'child_process';
 import { UPSTREAM_TEMPLATE_REPO } from './utils/load-template-config.js';
+import { tryLoadCache, isForceRefresh } from './utils/cache-helper.js';
+import { detectBaseUrl } from './utils/detect-repo.js';
+
+// 6 hours: stars/forks/traffic move slowly; orphan-search results are
+// weeks-lagged anyway, so this threshold trades freshness for staying
+// well clear of GitHub's secondary /search/code rate limit.
+const CACHE_MAX_AGE_MS = 6 * 60 * 60 * 1000;
 
 const __filename = fileURLToPath(import.meta.url);
 const __dirname = dirname(__filename);
@@ -250,9 +262,50 @@ async function fetchOrphans(forks) {
   return orphans;
 }
 
+function makeBadge(stats) {
+  // shields.io endpoint badge: https://shields.io/badges/endpoint-badge
+  // Headline = deployed forks if known, else total forks (fallback for very
+  // early data); 0 when neither is set yet.
+  const headlineCount = stats.deployed_forks || stats.forks || 0;
+  return {
+    schemaVersion: 1,
+    label: 'forks deployed',
+    message: headlineCount > 0 ? `${headlineCount}+` : '0',
+    color: headlineCount > 0 ? 'brightgreen' : 'lightgrey',
+    cacheSeconds: 3600,
+  };
+}
+
 async function main() {
   console.log(`📊 Fetching stats for ${REPO}...`);
   console.log(`   auth: ${TOKEN ? 'token present' : 'unauthenticated (60 req/hr)'}\n`);
+
+  // Cache check — every JSON we wrote in a previous deploy is publicly served
+  // at <site>/data/template-stats.json, so we use the deployed site as a
+  // remote cache. This keeps us well clear of GitHub's /search/code rate
+  // limit on every-push deploys.
+  const baseUrl = detectBaseUrl();
+  const cached = await tryLoadCache({
+    localPath: OUT_FILE,
+    remoteUrl: baseUrl ? `${baseUrl}/data/template-stats.json` : undefined,
+    freshnessKey: 'last_updated',
+    maxAgeMs: CACHE_MAX_AGE_MS,
+  });
+  if (cached) {
+    console.log(
+      `  ✓ using cached stats (${cached.ageHours}h old, source=${cached.source}); skipping GitHub API`,
+    );
+    console.log(`    (set FORCE_REFRESH=1 to override)`);
+    // Cache helper already wrote the local stats file; regenerate the badge
+    // from cached numbers so it stays consistent with the headline count.
+    const badge = makeBadge(cached.data);
+    writeFileSync(BADGE_FILE, JSON.stringify(badge, null, 2));
+    console.log(`  ✅ Regenerated ${BADGE_FILE} from cache`);
+    return;
+  }
+  if (isForceRefresh()) {
+    console.log('  FORCE_REFRESH=1 — bypassing cache\n');
+  }
 
   const repo = await ghApi(`/repos/${REPO}`);
   console.log(
@@ -318,16 +371,7 @@ async function main() {
   writeFileSync(OUT_FILE, JSON.stringify(stats, null, 2));
   console.log(`\n✅ Wrote ${OUT_FILE}`);
 
-  // shields.io endpoint badge: https://shields.io/badges/endpoint-badge
-  const headlineCount = deployedForks.length || forks.length;
-  const badge = {
-    schemaVersion: 1,
-    label: 'forks deployed',
-    message: headlineCount > 0 ? `${headlineCount}+` : '0',
-    color: headlineCount > 0 ? 'brightgreen' : 'lightgrey',
-    cacheSeconds: 3600,
-  };
-  writeFileSync(BADGE_FILE, JSON.stringify(badge, null, 2));
+  writeFileSync(BADGE_FILE, JSON.stringify(makeBadge(stats), null, 2));
   console.log(`✅ Wrote ${BADGE_FILE}`);
 }
 

--- a/scripts/utils/cache-helper.js
+++ b/scripts/utils/cache-helper.js
@@ -1,0 +1,134 @@
+/**
+ * Cache helper for build-time API fetchers.
+ *
+ * Lets fetcher scripts skip remote API calls when previously-generated
+ * data is still fresh enough. The deployed site itself acts as the
+ * "remote cache" — every JSON we write under client/public/data/ is
+ * publicly served at <site>/data/<file>.
+ *
+ * Lookup order:
+ *   1. Local file (most recent prior run on this runner, if any)
+ *   2. Remote file (the live deployed site)
+ *   3. Cache miss → caller does the actual API fetch
+ *
+ * Usage:
+ *
+ *   import { tryLoadCache } from './utils/cache-helper.js';
+ *
+ *   const cached = await tryLoadCache({
+ *     localPath: OUT_FILE,
+ *     remoteUrl: 'https://subhayu.in/data/pypi-stats.json',
+ *     freshnessKey: 'fetched_at',
+ *     maxAgeMs: 12 * 60 * 60 * 1000,
+ *   });
+ *   if (cached) {
+ *     console.log(`✓ using cached data (${cached.ageHours}h old)`);
+ *     return;
+ *   }
+ *   // …fall through to the API fetch
+ *
+ * Honors process.env.FORCE_REFRESH === '1' to bypass entirely.
+ */
+
+import fs from 'fs';
+import path from 'path';
+
+const FORCE_REFRESH = process.env.FORCE_REFRESH === '1';
+
+function readJsonIfExists(filePath) {
+  if (!fs.existsSync(filePath)) return null;
+  try {
+    return JSON.parse(fs.readFileSync(filePath, 'utf8'));
+  } catch {
+    return null;
+  }
+}
+
+async function fetchJsonOrNull(url) {
+  try {
+    const res = await fetch(url, {
+      headers: { Accept: 'application/json' },
+      // 5-second timeout — we don't want to block the build on a slow CDN
+      signal: AbortSignal.timeout(5000),
+    });
+    if (!res.ok) return null;
+    return await res.json();
+  } catch {
+    return null;
+  }
+}
+
+function ageMs(json, freshnessKey) {
+  const ts = json?.[freshnessKey];
+  if (!ts) return Infinity;
+  const parsed = Date.parse(ts);
+  if (Number.isNaN(parsed)) return Infinity;
+  return Date.now() - parsed;
+}
+
+/**
+ * Try to populate a local cache file from prior data; return parsed data
+ * + age info on hit, null on miss.
+ *
+ * On cache hit, this writes the cached JSON to localPath (so downstream
+ * steps in the build pipeline see the file) and returns
+ * { data, ageHours, source }. On miss, returns null.
+ *
+ * @param {object}  opts
+ * @param {string}  opts.localPath     absolute path to the cache file
+ * @param {string=} opts.remoteUrl     optional fallback URL (deployed site)
+ * @param {string=} opts.freshnessKey  JSON key holding the ISO timestamp
+ *                                     (default: 'fetched_at')
+ * @param {number}  opts.maxAgeMs      freshness threshold in milliseconds
+ * @returns {Promise<null | { data: any, ageHours: number, source: 'local' | 'remote' }>}
+ */
+export async function tryLoadCache({
+  localPath,
+  remoteUrl,
+  freshnessKey = 'fetched_at',
+  maxAgeMs,
+}) {
+  if (FORCE_REFRESH) return null;
+  if (!Number.isFinite(maxAgeMs) || maxAgeMs <= 0) return null;
+
+  // 1. Local file
+  const local = readJsonIfExists(localPath);
+  if (local) {
+    const age = ageMs(local, freshnessKey);
+    if (age < maxAgeMs) {
+      return {
+        data: local,
+        ageHours: Math.round((age / 3_600_000) * 10) / 10,
+        source: 'local',
+      };
+    }
+  }
+
+  // 2. Remote file (deployed site as cache)
+  if (remoteUrl) {
+    const remote = await fetchJsonOrNull(remoteUrl);
+    if (remote) {
+      const age = ageMs(remote, freshnessKey);
+      if (age < maxAgeMs) {
+        // Write to local so downstream build steps find it where they expect
+        fs.mkdirSync(path.dirname(localPath), { recursive: true });
+        fs.writeFileSync(localPath, JSON.stringify(remote, null, 2), 'utf8');
+        return {
+          data: remote,
+          ageHours: Math.round((age / 3_600_000) * 10) / 10,
+          source: 'remote',
+        };
+      }
+    }
+  }
+
+  return null;
+}
+
+/**
+ * Whether the current run was launched with FORCE_REFRESH=1.
+ * Useful for logging.
+ */
+export function isForceRefresh() {
+  return FORCE_REFRESH;
+}


### PR DESCRIPTION
## Summary

Stops every push to \`personal\` from re-hitting PyPI + GitHub APIs and getting 429s on the \`/search/code\` orphan-detection queries. Uses the **deployed site itself as the remote cache** — every JSON written under \`client/public/data/\` is publicly served at \`<site>/data/<file>\`, so a fresh deploy reads from its own previous deploy before reaching for any external API.

## Lookup order (per fetcher)

1. **Local file** on this runner (most recent prior run, if any)
2. **Remote file** on the deployed site (e.g. \`subhayu.in/data/pypi-stats.json\`)
3. **Cache miss** → caller does the actual API fetch as before

\`FORCE_REFRESH=1\` bypasses entirely. The daily/weekly cron workflows pass it.

## What's in this PR

- \`scripts/utils/cache-helper.js\` *(new)* — small \`tryLoadCache()\` helper. ~120 lines, no deps.
- \`scripts/fetch-pypi-stats.js\` — wired to cache helper, **12-hour** freshness threshold (PyPI counts move slowly).
- \`scripts/fetch-stats.js\` — wired to cache helper, **6-hour** freshness threshold. Badge generation extracted to \`makeBadge(stats)\` so the cache-hit path can regenerate the badge from cached numbers without an API call.
- \`.github/workflows/deploy.yaml\` — adds \`workflow_dispatch.inputs.force_refresh\` (boolean, default false) and threads it to a \`FORCE_REFRESH\` env var on the build step.
- \`.github/workflows/refresh-pypi-stats.yaml\` — passes \`force_refresh: true\` so the Monday cron actually performs the fetch instead of no-opping against fresh cache.
- \`.github/workflows/refresh-stats.yaml\` — same treatment for the daily cron.

## Why this kills the 429

\`fetch-stats.js\` runs four \`/search/code\` queries per build for orphan detection. That endpoint sits behind GitHub's secondary rate limit (~30 req/min in practice). With every push triggering a fresh fetch, multiple deploys per hour push us over. With this PR, those queries fire **at most every 6 hours** under normal pushes, plus once a day on the cron.

## Forker friendly

\`detectBaseUrl()\` (already in the codebase) computes the deployed URL from \`GITHUB_REPOSITORY\`, so a forker's deploys read from \`https://<their-username>.github.io/...\` automatically. First-deploy edge case (no prior data exists yet) is fine: remote fetch fails → cache miss → API fetch as before.

## Test plan

- [x] \`scripts/utils/cache-helper.js\` smoke-tested standalone (cold cache → remote hit, warm cache → local hit, tight max-age → miss)
- [x] \`fetch-pypi-stats.js\`: cold cache pulls \`pypi-stats.json\` from subhayu.in (source=remote, 0.3h old), warm cache hits local (source=local), \`FORCE_REFRESH=1\` bypasses
- [x] \`fetch-stats.js\`: cold cache pulls \`template-stats.json\` + regenerates badge from cached numbers, warm cache hits local
- [x] All three workflow YAML files parse cleanly (\`yaml.safe_load\`)
- [x] No new dependencies
- [ ] CI: open PR, merge, observe deploy log shows "✓ using cached" lines on a regular push
- [ ] CI: manual \`gh workflow run refresh-stats.yaml\` shows \`FORCE_REFRESH=1 — bypassing cache\` and performs the actual fetch

## Out of scope

- **Splitting orphan-search into its own cache layer** with a longer threshold than the rest of \`fetch-stats.js\`. Deferred — the unified 6-hour threshold solves the 429 problem with much simpler code.
- **GitHub Actions \`actions/cache@v4\`** — not needed; the deployed site is already a cache.
- **Caching \`resume.json\`** or \`ai-resume-prompt.txt\` — they're deterministic from \`resume.yaml\` and \`shared/schema.ts\`; no APIs involved.