### PR TITLE
fix(gui): hero chromatic-tint + secret-text selection follow theme accent

### DIFF
--- a/client/src/components/gui/HeroSection.tsx
+++ b/client/src/components/gui/HeroSection.tsx
@@ -196,7 +196,7 @@ export default function HeroSection({ data, pypiStats, onTripleTap, onTriggerRac
             className="block text-7xl sm:text-8xl md:text-[10rem] lg:text-[12rem] transition-all duration-150 ease-out will-change-transform"
             style={{
               transform: `translate(${mouse.x * 12}px, ${mouse.y * 6}px)`,
-              textShadow: `${mouse.x * -3}px ${mouse.y * -2}px 0 rgba(0,255,0,0.25), ${mouse.x * 3}px ${mouse.y * 2}px 0 rgba(0,100,255,0.12)`,
+              textShadow: `${mouse.x * -3}px ${mouse.y * -2}px 0 rgba(var(--gui-accent-rgb),0.25), ${mouse.x * 3}px ${mouse.y * 2}px 0 rgba(0,100,255,0.12)`,
             }}
           >
             {firstName}
@@ -205,7 +205,7 @@ export default function HeroSection({ data, pypiStats, onTripleTap, onTriggerRac
             className="block text-5xl sm:text-6xl md:text-[7rem] lg:text-[8rem] sm:ml-[10%] md:ml-[15%] transition-all duration-300 ease-out will-change-transform"
             style={{
               transform: `translate(${mouse.x * -8}px, ${mouse.y * -4}px)`,
-              textShadow: `${mouse.x * 2}px ${mouse.y * 1.5}px 0 rgba(0,255,0,0.2), ${mouse.x * -2}px ${mouse.y * -1.5}px 0 rgba(0,100,255,0.1)`,
+              textShadow: `${mouse.x * 2}px ${mouse.y * 1.5}px 0 rgba(var(--gui-accent-rgb),0.2), ${mouse.x * -2}px ${mouse.y * -1.5}px 0 rgba(0,100,255,0.1)`,
             }}
           >
             {restName}

--- a/client/src/index.css
+++ b/client/src/index.css
@@ -220,11 +220,11 @@ html {
   }
   .secret-text::selection {
     color: var(--gui-accent);
-    background: rgba(0, 255, 0, 0.15);
+    background: rgba(var(--gui-accent-rgb), 0.15);
   }
   .secret-text::-moz-selection {
     color: var(--gui-accent);
-    background: rgba(0, 255, 0, 0.15);
+    background: rgba(var(--gui-accent-rgb), 0.15);
   }
 
   /* Film grain overlay — applied site-wide on both TUI and GUI so


### PR DESCRIPTION
## Summary

Two visual elements hardcoded \`rgba(0, 255, 0, …)\` (matrix-green) instead of following the theme accent. Most visible on the giant hero name — even with amber/blue/pink themes active, the chromatic-aberration text-shadow on \`SUBHAYU KUMAR BALA\` rendered with a faint **green** fringe on letter edges.

## What changed

- **\`client/src/components/gui/HeroSection.tsx\`** — both name spans' parallax text-shadow now use \`rgba(var(--gui-accent-rgb), …)\`.
- **\`client/src/index.css\`** — \`.secret-text::selection\` and \`::-moz-selection\` backgrounds now use \`rgba(var(--gui-accent-rgb), 0.15)\`.

The cool counterpart shadow (\`rgba(0, 100, 255, …)\`) stays static — it's the second half of an RGB split that reads as "screen artifact" rather than "theme color." Theming it would weaken the chromatic-aberration effect.

## Verification

Playwright probe with \`localStorage.gui-color-theme = 'amber'\`:

\`\`\`
Theme: amber. Expected --gui-accent-rgb: 255, 120, 0
Actual   --gui-accent-rgb: "255, 120, 0"
Computed text-shadow: rgba(255, 120, 0, 0.25) -2.16px -0.78px 0px,
                      rgba(0, 100, 255, 0.12) 2.16px 0.78px 0px
\`\`\`

Before: green tint on letter edges regardless of theme.
After: tint follows the active accent (amber → orange tint, blue → blue tint, etc.).

\`npm run type-check\` produces the same 20 pre-existing errors, none new.