### PR TITLE
feat(build): opt-in Cloudflare Web Analytics via VITE_CF_BEACON_TOKEN

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -46,12 +46,16 @@ NODE_ENV=development
 # ANALYTICS (Optional)
 # ============================================================================
 
-# Google Analytics Measurement ID
-# Get yours at: https://analytics.google.com
-# VITE_GA_MEASUREMENT_ID=G-XXXXXXXXXX
-
-# Plausible Analytics domain
-# VITE_PLAUSIBLE_DOMAIN=yourdomain.com
+# Cloudflare Web Analytics beacon token.
+# When set at build time, the build:
+#   1. Injects the Cloudflare beacon <script> into index.html
+#   2. Adds the two Cloudflare origins to the CSP allowlist
+# When unset, the template ships with a tight CSP and no beacon.
+#
+# How to get one:
+#   dash.cloudflare.com → Web Analytics → your site → Setup
+#   → copy the value of `data-cf-beacon`'s "token" field
+# VITE_CF_BEACON_TOKEN=your_beacon_token_here
 
 # ============================================================================
 # EXTERNAL INTEGRATIONS (Optional - for future features)

--- a/.github/workflows/deploy.yaml
+++ b/.github/workflows/deploy.yaml
@@ -137,6 +137,10 @@ jobs:
         # cache helpers. On normal pushes this stays unset, so each deploy
         # reuses fresh JSON from the previous run / the live site.
         FORCE_REFRESH: ${{ github.event.inputs.force_refresh == 'true' && '1' || '' }}
+        # Cloudflare Web Analytics beacon token. Optional — when unset, the
+        # build no-ops the analytics plugin and the template's tight CSP
+        # stays in place. Set as a repo secret to enable tracking.
+        VITE_CF_BEACON_TOKEN: ${{ secrets.VITE_CF_BEACON_TOKEN }}
 
 
     - name: ⚙️  Configure GitHub Pages

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -79,6 +79,29 @@ const templateSignaturePlugin = (): Plugin => {
   };
 };
 
+const cloudflareAnalyticsPlugin = (): Plugin => {
+  return {
+    name: 'cloudflare-analytics-injector',
+    transformIndexHtml(html) {
+      const token = process.env.VITE_CF_BEACON_TOKEN;
+      if (!token) return html;
+
+      html = html.replace(
+        "script-src 'self' 'unsafe-inline'",
+        "script-src 'self' 'unsafe-inline' static.cloudflareinsights.com"
+      );
+      html = html.replace(
+        "connect-src 'self'",
+        "connect-src 'self' cloudflareinsights.com"
+      );
+
+      const beaconConfig = JSON.stringify({ token });
+      const snippet = `    <!-- Cloudflare Web Analytics -->\n    <script defer src="https://static.cloudflareinsights.com/beacon.min.js" data-cf-beacon='${beaconConfig}'></script>\n  `;
+      return html.replace('</body>', `${snippet}</body>`);
+    },
+  };
+};
+
 const buildVersionPlugin = (): Plugin => {
   return {
     name: 'build-version',
@@ -108,6 +131,7 @@ export default defineConfig({
     themeInjectorPlugin(),
     siteMetadataPlugin(),
     templateSignaturePlugin(),
+    cloudflareAnalyticsPlugin(),
     buildVersionPlugin(),
     ...(process.env.NODE_ENV !== "production" &&
     process.env.REPL_ID !== undefined


### PR DESCRIPTION
## Summary

- Adds a `cloudflareAnalyticsPlugin` to `vite.config.ts` that injects the Cloudflare beacon `<script>` AND patches the CSP allowlist (`static.cloudflareinsights.com` for `script-src`, `cloudflareinsights.com` for `connect-src`) **only** when `VITE_CF_BEACON_TOKEN` is set at build time. When unset, the template ships unchanged — tight CSP, no third-party beacon — so forks aren't pinged with anyone else's token.
- Threads `VITE_CF_BEACON_TOKEN` from a GitHub repo secret through `.github/workflows/deploy.yaml` so the deployed branch picks it up.
- Replaces the dead `VITE_GA_MEASUREMENT_ID` + `VITE_PLAUSIBLE_DOMAIN` entries in `.env.example` with the new `VITE_CF_BEACON_TOKEN` slot. The two old entries weren't wired into any plugin and the existing CSP would have blocked both anyway, so they were misleading documentation.

## Why

The CSP at `client/index.html:10` blocks both the Cloudflare beacon download (`script-src`) and its outbound pageview POST (`connect-src`). On top of that, the beacon snippet wasn't pasted anywhere. So the live site at subhayu.in tracks zero pageviews from `/` despite Cloudflare's "Automatic setup" claim — only sub-paths with looser CSPs (e.g. `/DocumentAccessPOC/*`) showed up in the dashboard.

Hardcoding the token directly into `client/index.html` would have leaked it into every fork of this template. The plugin pattern matches the existing `themeInjectorPlugin` / `siteMetadataPlugin` / `templateSignaturePlugin` design — config-driven, opt-in, no surprises for forkers.

## Test plan

- [x] `npx vite build` with `VITE_CF_BEACON_TOKEN` unset → output `dist/public/index.html` contains zero `cloudflareinsights` references and the original CSP
- [x] `VITE_CF_BEACON_TOKEN=… npx vite build` → CSP gains both Cloudflare origins, beacon `<script>` appears before `</body>` with the token in `data-cf-beacon`
- [ ] After merge + sync to `personal` + repo secret added: `curl -sL https://subhayu.in/ | grep cloudflareinsights` returns the CSP line + the script tag
- [ ] Visit subhayu.in in a browser, watch DevTools Network for `beacon.min.js` (200) + the report POST (204), then confirm pageviews appear in the Cloudflare dashboard within a few minutes

## CSP tradeoff

When the token is set, `script-src` allows any script Cloudflare hosts at `static.cloudflareinsights.com`. Standard analytics tradeoff. Plugin only loosens the CSP when the token is set, so forks of `main` keep the strict default unless they opt in.

🤖 Generated with [Claude Code](https://claude.com/claude-code)